### PR TITLE
Added constructor in RTB for objects without default constructor

### DIFF
--- a/include/realtime_tools/realtime_buffer.h
+++ b/include/realtime_tools/realtime_buffer.h
@@ -56,6 +56,18 @@ class RealtimeBuffer
     realtime_data_ = new T();
   }
 
+  /**
+   * @brief Constructor for objects that don't have
+   * a default constructor
+   * @param data The object to use as default value
+   */
+  RealtimeBuffer(const T& data)
+  {
+    // allocate memory
+    non_realtime_data_ = new T(data);
+    realtime_data_ = new T(data);
+  }
+
   ~RealtimeBuffer()
   {
     if (non_realtime_data_)


### PR DESCRIPTION
This allows storing objects that don't have default constructors, e.g. ros::Rate
example:
```cpp
class Controller {
 public:
  Controller() : controller_frequency_(ros::Rate(1000)) {}
 private:
  void controlLoop() {
     while(ros::ok()) {
       read();
       update();
       write();
       controller_frequency_.readFromRT()->sleep();
     }
  }

  void reconfigure(...) {
    ros::Rate r(new_frequency);
    controller_frequency_.writeFromNonRT(r);
  }

  realtime_tools::RealtimeBuffer<ros::Rate> controller_frequency_;