### PR TITLE
Fix NON_POLLING version of realtime_publisher

### DIFF
--- a/include/realtime_tools/realtime_publisher.h
+++ b/include/realtime_tools/realtime_publisher.h
@@ -37,7 +37,6 @@
  */
 #ifndef REALTIME_TOOLS__REALTIME_PUBLISHER_H_
 #define REALTIME_TOOLS__REALTIME_PUBLISHER_H_
-#define NON_POLLING
 
 #include <string>
 #include <ros/node_handle.h>


### PR DESCRIPTION
As is, the code didn't compile with NON_POLLING defined.  Here's a pull request which fixes that.  It modifies lock and unlock for the NON_POLLING case to use a boost::unique_lock to lock rather than a bare mutex. This was necessary since that's what is used by boost::condition_variable wait and notify.  