### PR TITLE
C++11 and melodic travis updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,11 @@ notifications:
 
 env:
   global:
-    - UPSTREAM_WORKSPACE=https://raw.github.com/ros-controls/ros_control/kinetic-devel/ros_control.rosinstall
+    - UPSTREAM_WORKSPACE=https://raw.github.com/ros-controls/ros_control/melodic-devel/ros_control.rosinstall
     - ROS_PARALLEL_TEST_JOBS=-j1
   matrix:
-    - ROS_DISTRO=kinetic ROS_REPO=ros
-    - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed
-    - ROS_DISTRO=lunar   ROS_REPO=ros
-    - ROS_DISTRO=lunar   ROS_REPO=ros-shadow-fixed
-  
+    - ROS_DISTRO=melodic ROS_REPO=ros
+    - ROS_DISTRO=melodic ROS_REPO=ros-shadow-fixed
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 script:

--- a/include/realtime_tools/realtime_publisher.h
+++ b/include/realtime_tools/realtime_publisher.h
@@ -227,6 +227,10 @@ private:
   int turn_;  // Who's turn is it to use msg_?
 };
 
+#include <memory>
+template <class Msg>
+using RealtimePublisherSharedPtr = std::shared_ptr<RealtimePublisher<Msg> >;
+
 }
 
 #endif


### PR DESCRIPTION
`RealtimePublisherSharedPtr` is to be used in `ros_controllers` to replace some looong `boost::shared_ptr` declarations and typedef..