### PR TITLE
Made RealtimeBuffer's copy-constructor const

### DIFF
--- a/include/realtime_tools/realtime_buffer.h
+++ b/include/realtime_tools/realtime_buffer.h
@@ -76,7 +76,7 @@ class RealtimeBuffer
       delete realtime_data_;
   }
 
-  RealtimeBuffer(RealtimeBuffer &source)
+  RealtimeBuffer(const RealtimeBuffer &source)
   {
     // allocate memory
     non_realtime_data_ = new T();


### PR DESCRIPTION
The copy constructor on the realtime buffer doesn't follow the standard copy-constructor format of pass-by-const-reference, but rather uses pass-by-reference. There is no reason for this, it should be const to be const-correct and follow standard copy-constructor idioms. This change also will allow RealtimeBuffer to be an STL container element.

I've opened this PR against `melodic-devel`, but the file `realtime_buffer.h` is identical between kinetic and melodic so ideally I would like to see this change cherry picked backward to at least `kinetic-devel`.