### PR TITLE
use this_thread::sleep_for on Windows

### DIFF
--- a/include/realtime_tools/realtime_buffer.h
+++ b/include/realtime_tools/realtime_buffer.h
@@ -40,8 +40,11 @@
 #define REALTIME_TOOLS__REALTIME_BUFFER_H_
 
 #include <boost/thread/mutex.hpp>
-#include <chrono>
-#include <thread>
+
+#ifdef _WIN32
+  #include <chrono>
+  #include <thread>
+#endif
 
 namespace realtime_tools
 {
@@ -156,7 +159,13 @@ class RealtimeBuffer
     mutex_.lock();
 #else
     while (!mutex_.try_lock())
+    {
+#ifdef _WIN32
       std::this_thread::sleep_for(std::chrono::microseconds(500));
+#else
+      usleep(500);
+#endif
+    }
 #endif
   }
 

--- a/include/realtime_tools/realtime_buffer.h
+++ b/include/realtime_tools/realtime_buffer.h
@@ -40,11 +40,8 @@
 #define REALTIME_TOOLS__REALTIME_BUFFER_H_
 
 #include <boost/thread/mutex.hpp>
-
-#ifdef _WIN32
-  #include <chrono>
-  #include <thread>
-#endif
+#include <chrono>
+#include <thread>
 
 namespace realtime_tools
 {
@@ -160,11 +157,7 @@ class RealtimeBuffer
 #else
     while (!mutex_.try_lock())
     {
-#ifdef _WIN32
       std::this_thread::sleep_for(std::chrono::microseconds(500));
-#else
-      usleep(500);
-#endif
     }
 #endif
   }

--- a/include/realtime_tools/realtime_buffer.h
+++ b/include/realtime_tools/realtime_buffer.h
@@ -40,6 +40,8 @@
 #define REALTIME_TOOLS__REALTIME_BUFFER_H_
 
 #include <boost/thread/mutex.hpp>
+#include <chrono>
+#include <thread>
 
 namespace realtime_tools
 {
@@ -154,7 +156,7 @@ class RealtimeBuffer
     mutex_.lock();
 #else
     while (!mutex_.try_lock())
-      usleep(500);
+      std::this_thread::sleep_for(std::chrono::microseconds(500));
 #endif
   }
 

--- a/include/realtime_tools/realtime_publisher.h
+++ b/include/realtime_tools/realtime_publisher.h
@@ -44,11 +44,8 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/thread/condition.hpp>
-
-#ifdef _WIN32
-  #include <chrono>
-  #include <thread>
-#endif
+#include <chrono>
+#include <thread>
 
 namespace realtime_tools {
 
@@ -84,11 +81,7 @@ public:
     stop();
     while (is_running())
     {
-#ifdef _WIN32
       std::this_thread::sleep_for(std::chrono::microseconds(100));
-#else
-      usleep(100);
-#endif
     }
 
     publisher_.shutdown();
@@ -165,11 +158,7 @@ public:
     // never actually block on the lock
     while (!msg_mutex_.try_lock())
     {
-#ifdef _WIN32
       std::this_thread::sleep_for(std::chrono::microseconds(200));
-#else
-      usleep(200);
-#endif
     }
 #endif
   }
@@ -210,13 +199,7 @@ private:
         updated_cond_.wait(lock);
 #else
         unlock();
-
-#ifdef _WIN32
         std::this_thread::sleep_for(std::chrono::microseconds(500));
-#else
-        usleep(500);
-#endif
-
         lock();
 #endif
       }

--- a/include/realtime_tools/realtime_publisher.h
+++ b/include/realtime_tools/realtime_publisher.h
@@ -44,8 +44,11 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/thread/condition.hpp>
-#include <chrono>
-#include <thread>
+
+#ifdef _WIN32
+  #include <chrono>
+  #include <thread>
+#endif
 
 namespace realtime_tools {
 
@@ -80,7 +83,13 @@ public:
   {
     stop();
     while (is_running())
+    {
+#ifdef _WIN32
       std::this_thread::sleep_for(std::chrono::microseconds(100));
+#else
+      usleep(100);
+#endif
+    }
 
     publisher_.shutdown();
   }
@@ -155,7 +164,13 @@ public:
 #else
     // never actually block on the lock
     while (!msg_mutex_.try_lock())
+    {
+#ifdef _WIN32
       std::this_thread::sleep_for(std::chrono::microseconds(200));
+#else
+      usleep(200);
+#endif
+    }
 #endif
   }
 
@@ -192,11 +207,17 @@ private:
       while (turn_ != NON_REALTIME && keep_running_)
       {
 #ifdef NON_POLLING
-	updated_cond_.wait(lock);
+        updated_cond_.wait(lock);
 #else
-	unlock();
-	std::this_thread::sleep_for(std::chrono::microseconds(500));
-	lock();
+        unlock();
+
+#ifdef _WIN32
+        std::this_thread::sleep_for(std::chrono::microseconds(500));
+#else
+        usleep(500);
+#endif
+
+        lock();
 #endif
       }
       outgoing = msg_;

--- a/include/realtime_tools/realtime_publisher.h
+++ b/include/realtime_tools/realtime_publisher.h
@@ -44,6 +44,8 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/thread/condition.hpp>
+#include <chrono>
+#include <thread>
 
 namespace realtime_tools {
 
@@ -78,7 +80,7 @@ public:
   {
     stop();
     while (is_running())
-      usleep(100);
+      std::this_thread::sleep_for(std::chrono::microseconds(100));
 
     publisher_.shutdown();
   }
@@ -153,7 +155,7 @@ public:
 #else
     // never actually block on the lock
     while (!msg_mutex_.try_lock())
-      usleep(200);
+      std::this_thread::sleep_for(std::chrono::microseconds(200));
 #endif
   }
 
@@ -193,7 +195,7 @@ private:
 	updated_cond_.wait(lock);
 #else
 	unlock();
-	usleep(500);
+	std::this_thread::sleep_for(std::chrono::microseconds(500));
 	lock();
 #endif
       }

--- a/src/realtime_clock.cpp
+++ b/src/realtime_clock.cpp
@@ -37,11 +37,8 @@
  */
 
 #include <realtime_tools/realtime_clock.h>
-
-#ifdef _WIN32
-  #include <chrono>
-  #include <thread>
-#endif
+#include <chrono>
+#include <thread>
 
 namespace realtime_tools
 {
@@ -132,11 +129,7 @@ namespace realtime_tools
 #else
     while (!mutex_.try_lock())
     {
-#ifdef _WIN32
       std::this_thread::sleep_for(std::chrono::microseconds(500));
-#else
-      usleep(500);
-#endif
     }
 #endif
   }

--- a/src/realtime_clock.cpp
+++ b/src/realtime_clock.cpp
@@ -37,8 +37,11 @@
  */
 
 #include <realtime_tools/realtime_clock.h>
-#include <chrono>
-#include <thread>
+
+#ifdef _WIN32
+  #include <chrono>
+  #include <thread>
+#endif
 
 namespace realtime_tools
 {
@@ -128,7 +131,13 @@ namespace realtime_tools
     mutex_.lock();
 #else
     while (!mutex_.try_lock())
+    {
+#ifdef _WIN32
       std::this_thread::sleep_for(std::chrono::microseconds(500));
+#else
+      usleep(500);
+#endif
+    }
 #endif
   }
 

--- a/src/realtime_clock.cpp
+++ b/src/realtime_clock.cpp
@@ -37,6 +37,8 @@
  */
 
 #include <realtime_tools/realtime_clock.h>
+#include <chrono>
+#include <thread>
 
 namespace realtime_tools
 {
@@ -126,7 +128,7 @@ namespace realtime_tools
     mutex_.lock();
 #else
     while (!mutex_.try_lock())
-      usleep(500);
+      std::this_thread::sleep_for(std::chrono::microseconds(500));
 #endif
   }
 


### PR DESCRIPTION
`usleep` is not available on Windows, replace it with `this_thread::sleep_for` (available since c++11)

also a minor indentation update in include/realtime_tools/realtime_publisher.h, converted existing tabs to spaces