### PR TITLE
Add unit tests + fix publisher bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,11 @@ if (TARGET realtime_buffer_tests)
   target_link_libraries(realtime_buffer_tests PRIVATE ${PROJECT_NAME})
 endif()
 
+catkin_add_gtest(realtime_clock_tests test/realtime_clock_tests.cpp)
+if (TARGET realtime_clock_tests)
+  target_link_libraries(realtime_clock_tests PRIVATE ${PROJECT_NAME})
+endif()
+
 # Install
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,13 @@ if (CATKIN_ENABLE_TESTING)
     target_link_libraries(realtime_publisher_tests ${PROJECT_NAME} ${std_msgs_LIBRARIES})
     target_include_directories(realtime_publisher_tests PRIVATE ${std_msgs_INCLUDE_DIRS})
   endif()
+
+  add_rostest_gtest(realtime_server_goal_handle_tests test/realtime_server_goal_handle.test test/realtime_server_goal_handle_tests.cpp)
+  if (TARGET realtime_server_goal_handle_tests)
+    find_package(actionlib REQUIRED)
+    target_link_libraries(realtime_server_goal_handle_tests ${PROJECT_NAME} ${actionlib_LIBRARIES})
+    target_include_directories(realtime_publisher_tests PRIVATE ${actionlib_INCLUDE_DIRS})
+  endif()
 endif()
 
 # Install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,34 +21,24 @@ target_link_libraries(${PROJECT_NAME} PUBLIC ${catkin_LIBRARIES} ${Boost_LIBRARI
 # Unit Tests
 if (CATKIN_ENABLE_TESTING)
   catkin_add_gtest(realtime_box_tests test/realtime_box_tests.cpp)
-  if (TARGET realtime_box_tests)
-    target_link_libraries(realtime_box_tests ${PROJECT_NAME})
-  endif()
+  target_link_libraries(realtime_box_tests ${PROJECT_NAME})
 
   catkin_add_gtest(realtime_buffer_tests test/realtime_buffer_tests.cpp)
-  if (TARGET realtime_buffer_tests)
-    target_link_libraries(realtime_buffer_tests ${PROJECT_NAME})
-  endif()
+  target_link_libraries(realtime_buffer_tests ${PROJECT_NAME})
 
   catkin_add_gtest(realtime_clock_tests test/realtime_clock_tests.cpp)
-  if (TARGET realtime_clock_tests)
-    target_link_libraries(realtime_clock_tests ${PROJECT_NAME})
-  endif()
+  target_link_libraries(realtime_clock_tests ${PROJECT_NAME})
 
   find_package(rostest REQUIRED)
   add_rostest_gtest(realtime_publisher_tests test/realtime_publisher.test test/realtime_publisher_tests.cpp)
-  if (TARGET realtime_publisher_tests)
-    find_package(std_msgs REQUIRED)
-    target_link_libraries(realtime_publisher_tests ${PROJECT_NAME} ${std_msgs_LIBRARIES})
-    target_include_directories(realtime_publisher_tests PRIVATE ${std_msgs_INCLUDE_DIRS})
-  endif()
+  find_package(std_msgs REQUIRED)
+  target_link_libraries(realtime_publisher_tests ${PROJECT_NAME} ${std_msgs_LIBRARIES})
+  target_include_directories(realtime_publisher_tests PRIVATE ${std_msgs_INCLUDE_DIRS})
 
   add_rostest_gtest(realtime_server_goal_handle_tests test/realtime_server_goal_handle.test test/realtime_server_goal_handle_tests.cpp)
-  if (TARGET realtime_server_goal_handle_tests)
-    find_package(actionlib REQUIRED)
-    target_link_libraries(realtime_server_goal_handle_tests ${PROJECT_NAME} ${actionlib_LIBRARIES})
-    target_include_directories(realtime_publisher_tests PRIVATE ${actionlib_INCLUDE_DIRS})
-  endif()
+  find_package(actionlib REQUIRED)
+  target_link_libraries(realtime_server_goal_handle_tests ${PROJECT_NAME} ${actionlib_LIBRARIES})
+  target_include_directories(realtime_publisher_tests PRIVATE ${actionlib_INCLUDE_DIRS})
 endif()
 
 # Install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,22 +20,22 @@ target_link_libraries(${PROJECT_NAME} PUBLIC ${catkin_LIBRARIES} ${Boost_LIBRARI
 
 # Unit Tests
 if (CATKIN_ENABLE_TESTING)
-  catkin_add_gtest(realtime_box_tests test/realtime_box_tests.cpp)
-  target_link_libraries(realtime_box_tests ${PROJECT_NAME})
+  catkin_add_gmock(realtime_box_tests test/realtime_box_tests.cpp)
+  target_link_libraries(realtime_box_tests ${PROJECT_NAME} ${GMOCK_MAIN_LIBRARIES})
 
-  catkin_add_gtest(realtime_buffer_tests test/realtime_buffer_tests.cpp)
-  target_link_libraries(realtime_buffer_tests ${PROJECT_NAME})
+  catkin_add_gmock(realtime_buffer_tests test/realtime_buffer_tests.cpp)
+  target_link_libraries(realtime_buffer_tests ${PROJECT_NAME} ${GMOCK_MAIN_LIBRARIES})
 
-  catkin_add_gtest(realtime_clock_tests test/realtime_clock_tests.cpp)
+  catkin_add_gmock(realtime_clock_tests test/realtime_clock_tests.cpp)
   target_link_libraries(realtime_clock_tests ${PROJECT_NAME})
 
   find_package(rostest REQUIRED)
-  add_rostest_gtest(realtime_publisher_tests test/realtime_publisher.test test/realtime_publisher_tests.cpp)
+  add_rostest_gmock(realtime_publisher_tests test/realtime_publisher.test test/realtime_publisher_tests.cpp)
   find_package(std_msgs REQUIRED)
   target_link_libraries(realtime_publisher_tests ${PROJECT_NAME} ${std_msgs_LIBRARIES})
   target_include_directories(realtime_publisher_tests PRIVATE ${std_msgs_INCLUDE_DIRS})
 
-  add_rostest_gtest(realtime_server_goal_handle_tests test/realtime_server_goal_handle.test test/realtime_server_goal_handle_tests.cpp)
+  add_rostest_gmock(realtime_server_goal_handle_tests test/realtime_server_goal_handle.test test/realtime_server_goal_handle_tests.cpp)
   find_package(actionlib REQUIRED)
   target_link_libraries(realtime_server_goal_handle_tests ${PROJECT_NAME} ${actionlib_LIBRARIES})
   target_include_directories(realtime_publisher_tests PRIVATE ${actionlib_INCLUDE_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,19 +19,21 @@ add_library(${PROJECT_NAME} src/realtime_clock.cpp)
 target_link_libraries(${PROJECT_NAME} PUBLIC ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 # Unit Tests
-catkin_add_gtest(realtime_box_tests test/realtime_box_tests.cpp)
-if (TARGET realtime_box_tests)
-  target_link_libraries(realtime_box_tests PRIVATE ${PROJECT_NAME})
-endif()
+if (CATKIN_ENABLE_TESTING)
+  catkin_add_gtest(realtime_box_tests test/realtime_box_tests.cpp)
+  if (TARGET realtime_box_tests)
+    target_link_libraries(realtime_box_tests ${PROJECT_NAME})
+  endif()
 
-catkin_add_gtest(realtime_buffer_tests test/realtime_buffer_tests.cpp)
-if (TARGET realtime_buffer_tests)
-  target_link_libraries(realtime_buffer_tests PRIVATE ${PROJECT_NAME})
-endif()
+  catkin_add_gtest(realtime_buffer_tests test/realtime_buffer_tests.cpp)
+  if (TARGET realtime_buffer_tests)
+    target_link_libraries(realtime_buffer_tests ${PROJECT_NAME})
+  endif()
 
-catkin_add_gtest(realtime_clock_tests test/realtime_clock_tests.cpp)
-if (TARGET realtime_clock_tests)
-  target_link_libraries(realtime_clock_tests PRIVATE ${PROJECT_NAME})
+  catkin_add_gtest(realtime_clock_tests test/realtime_clock_tests.cpp)
+  if (TARGET realtime_clock_tests)
+    target_link_libraries(realtime_clock_tests ${PROJECT_NAME})
+  endif()
 endif()
 
 # Install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,11 @@ if (TARGET realtime_box_tests)
   target_link_libraries(realtime_box_tests PRIVATE ${PROJECT_NAME})
 endif()
 
+catkin_add_gtest(realtime_buffer_tests test/realtime_buffer_tests.cpp)
+if (TARGET realtime_buffer_tests)
+  target_link_libraries(realtime_buffer_tests PRIVATE ${PROJECT_NAME})
+endif()
+
 # Install
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,13 @@ catkin_package(
   )
 
 add_library(${PROJECT_NAME} src/realtime_clock.cpp)
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} PUBLIC ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
+# Unit Tests
+catkin_add_gtest(realtime_box_tests test/realtime_box_tests.cpp)
+if (TARGET realtime_box_tests)
+  target_link_libraries(realtime_box_tests PRIVATE ${PROJECT_NAME})
+endif()
 
 # Install
 install(DIRECTORY include/${PROJECT_NAME}/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,14 @@ if (CATKIN_ENABLE_TESTING)
   if (TARGET realtime_clock_tests)
     target_link_libraries(realtime_clock_tests ${PROJECT_NAME})
   endif()
+
+  find_package(rostest REQUIRED)
+  add_rostest_gtest(realtime_publisher_tests test/realtime_publisher.test test/realtime_publisher_tests.cpp)
+  if (TARGET realtime_publisher_tests)
+    find_package(std_msgs REQUIRED)
+    target_link_libraries(realtime_publisher_tests ${PROJECT_NAME} ${std_msgs_LIBRARIES})
+    target_include_directories(realtime_publisher_tests PRIVATE ${std_msgs_INCLUDE_DIRS})
+  endif()
 endif()
 
 # Install

--- a/include/realtime_tools/realtime_publisher.h
+++ b/include/realtime_tools/realtime_publisher.h
@@ -65,13 +65,13 @@ public:
    * \param latched . optional argument (defaults to false) to specify is publisher is latched or not
    */
   RealtimePublisher(const ros::NodeHandle &node, const std::string &topic, int queue_size, bool latched=false)
-    : topic_(topic), node_(node), is_running_(false), keep_running_(false), turn_(REALTIME)
+    : topic_(topic), node_(node), is_running_(false), keep_running_(false), turn_(LOOP_NOT_STARTED)
   {
     construct(queue_size, latched);
   }
 
   RealtimePublisher()
-    : is_running_(false), keep_running_(false), turn_(REALTIME)
+    : is_running_(false), keep_running_(false), turn_(LOOP_NOT_STARTED)
   {
   }
 
@@ -229,7 +229,7 @@ private:
   boost::condition_variable updated_cond_;
 #endif
 
-  enum {REALTIME, NON_REALTIME};
+  enum {REALTIME, NON_REALTIME, LOOP_NOT_STARTED};
   int turn_;  // Who's turn is it to use msg_?
 };
 

--- a/package.xml
+++ b/package.xml
@@ -32,5 +32,5 @@
 
   <test_depend>rosunit</test_depend>
   <test_depend>rostest</test_depend>
-
+  <test_depend>actionlib</test_depend>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -31,5 +31,6 @@
   <run_depend>rospy</run_depend> 
 
   <test_depend>rosunit</test_depend>
+  <test_depend>rostest</test_depend>
 
 </package>

--- a/package.xml
+++ b/package.xml
@@ -30,4 +30,6 @@
   <run_depend>roscpp</run_depend> 
   <run_depend>rospy</run_depend> 
 
+  <test_depend>rosunit</test_depend>
+
 </package>

--- a/test/realtime_box_tests.cpp
+++ b/test/realtime_box_tests.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2019, Open Source Robotics Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+#include <realtime_tools/realtime_box.h>
+
+using realtime_tools::RealtimeBox;
+
+class DefaultConstructable
+{
+  public:
+    DefaultConstructable() : number_(42) {};
+    ~DefaultConstructable() {};
+    int number_;
+};
+
+TEST(RealtimeBox, default_construct)
+{
+  DefaultConstructable thing;
+  thing.number_ = 5;
+
+  RealtimeBox<DefaultConstructable> box;
+  box.get(thing);
+
+  EXPECT_EQ(42, thing.number_);
+}
+
+TEST(RealtimeBox, initial_value)
+{
+  RealtimeBox<double> box(3.14);
+  double num = 0.0;
+  box.get(num);
+  EXPECT_DOUBLE_EQ(3.14, num);
+}
+
+TEST(RealtimeBox, set_and_get)
+{
+  RealtimeBox<char> box('a');
+
+  {
+    const char input = 'z';
+    box.set(input);
+  }
+
+  char output = 'a';
+  box.get(output);
+  EXPECT_EQ('z', output);
+}
+
+int main(int argc, char ** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/realtime_box_tests.cpp
+++ b/test/realtime_box_tests.cpp
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include <realtime_tools/realtime_box.h>
 
 using realtime_tools::RealtimeBox;
@@ -71,9 +71,4 @@ TEST(RealtimeBox, set_and_get)
   char output = 'a';
   box.get(output);
   EXPECT_EQ('z', output);
-}
-
-int main(int argc, char ** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
 }

--- a/test/realtime_buffer_tests.cpp
+++ b/test/realtime_buffer_tests.cpp
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include <realtime_tools/realtime_buffer.h>
 
 using realtime_tools::RealtimeBuffer;
@@ -82,9 +82,4 @@ TEST(RealtimeBuffer, initRT)
   RealtimeBuffer<int> buffer(42);
   buffer.initRT(28);
   EXPECT_EQ(28, *buffer.readFromRT());
-}
-
-int main(int argc, char ** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
 }

--- a/test/realtime_buffer_tests.cpp
+++ b/test/realtime_buffer_tests.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2019, Open Source Robotics Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+#include <realtime_tools/realtime_buffer.h>
+
+using realtime_tools::RealtimeBuffer;
+
+class DefaultConstructable
+{
+  public:
+    DefaultConstructable() : number_(42) {};
+    ~DefaultConstructable() {};
+    int number_;
+};
+
+TEST(RealtimeBuffer, default_construct)
+{
+  RealtimeBuffer<DefaultConstructable> buffer;
+  EXPECT_EQ(42, buffer.readFromRT()->number_);
+}
+
+TEST(RealtimeBuffer, initial_value)
+{
+  RealtimeBuffer<double> buffer(3.14);
+  EXPECT_DOUBLE_EQ(3.14, *buffer.readFromRT());
+}
+
+TEST(RealtimeBuffer, copy_construct)
+{
+  const RealtimeBuffer<char> buffer('a');
+  RealtimeBuffer<char> buffer_copy(buffer);
+  EXPECT_EQ('a', *buffer_copy.readFromRT());
+}
+
+TEST(RealtimeBuffer, assignment_operator)
+{
+  const RealtimeBuffer<char> buffer('a');
+  RealtimeBuffer<char> buffer2('z');
+
+  EXPECT_EQ('z', *buffer2.readFromRT());
+  buffer2 = buffer;
+  EXPECT_EQ('a', *buffer2.readFromRT());
+}
+
+TEST(RealtimeBuffer, write_read_non_rt)
+{
+  RealtimeBuffer<int> buffer(42);
+
+  buffer.writeFromNonRT(28);
+  EXPECT_EQ(28, *buffer.readFromNonRT());
+}
+
+TEST(RealtimeBuffer, initRT)
+{
+  RealtimeBuffer<int> buffer(42);
+  buffer.initRT(28);
+  EXPECT_EQ(28, *buffer.readFromRT());
+}
+
+int main(int argc, char ** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/realtime_clock_tests.cpp
+++ b/test/realtime_clock_tests.cpp
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include <realtime_tools/realtime_clock.h>
 #include <chrono>
 #include <thread>

--- a/test/realtime_clock_tests.cpp
+++ b/test/realtime_clock_tests.cpp
@@ -42,7 +42,8 @@ TEST(RealtimeClock, get_system_time)
   RealtimeClock rt_clock;
   // Wait for time to be available
   ros::Time last_rt_time;
-  for (int i = 0; i < ATTEMPTS && ros::Time() == last_rt_time; ++i) {
+  for (int i = 0; i < ATTEMPTS && ros::Time() == last_rt_time; ++i)
+  {
     std::this_thread::sleep_for(DELAY);
     last_rt_time = rt_clock.getSystemTime(ros::Time());
   }

--- a/test/realtime_clock_tests.cpp
+++ b/test/realtime_clock_tests.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2019, Open Source Robotics Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+#include <realtime_tools/realtime_clock.h>
+#include <chrono>
+#include <thread>
+
+using realtime_tools::RealtimeClock;
+
+TEST(RealtimeClock, get_system_time)
+{
+  const int ATTEMPTS = 10;
+  const std::chrono::milliseconds DELAY(1);
+
+  RealtimeClock rt_clock;
+  // Wait for time to be available
+  ros::Time last_rt_time;
+  for (int i = 0; i < ATTEMPTS && ros::Time() == last_rt_time; ++i) {
+    std::this_thread::sleep_for(DELAY);
+    last_rt_time = rt_clock.getSystemTime(ros::Time());
+  }
+  ASSERT_NE(ros::Time(), last_rt_time);
+
+  // This test assumes system time will not jump backwards during it
+  EXPECT_GT(rt_clock.getSystemTime(last_rt_time), last_rt_time);
+}
+
+int main(int argc, char ** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ros::Time::init();
+  return RUN_ALL_TESTS();
+}

--- a/test/realtime_publisher.test
+++ b/test/realtime_publisher.test
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+  <test test-name="realtime_publisher_tests" pkg="realtime_tools" type="realtime_publisher_tests" />
+</launch>

--- a/test/realtime_publisher_tests.cpp
+++ b/test/realtime_publisher_tests.cpp
@@ -72,7 +72,8 @@ TEST(RealtimePublisher, rt_publish)
   RealtimePublisher<std_msgs::String> rt_pub(nh, "rt_publish", 10, latching);
   // publish a latched message
   bool lock_is_held = rt_pub.trylock();
-  for (size_t i = 0; i < ATTEMPTS && !lock_is_held; ++i) {
+  for (size_t i = 0; i < ATTEMPTS && !lock_is_held; ++i)
+  {
     lock_is_held = rt_pub.trylock();
     std::this_thread::sleep_for(DELAY);
   }

--- a/test/realtime_publisher_tests.cpp
+++ b/test/realtime_publisher_tests.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2019, Open Source Robotics Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+#include <realtime_tools/realtime_publisher.h>
+#include <std_msgs/String.h>
+#include <chrono>
+#include <mutex>
+#include <thread>
+
+using realtime_tools::RealtimePublisher;
+
+TEST(RealtimePublisher, construct_destruct)
+{
+  ros::NodeHandle nh;
+  RealtimePublisher<std_msgs::String> rt_pub(nh, "construct_destruct", 10);
+}
+
+TEST(RealtimePublisher, construct_init_destruct)
+{
+  RealtimePublisher<std_msgs::String> rt_pub;
+  ros::NodeHandle nh;
+  rt_pub.init(nh, "construct_init_destruct", 10);
+}
+
+struct StringCallback
+{
+  std_msgs::String msg_;
+  std::mutex mtx_;
+
+  void callback(const std_msgs::String & msg)
+  {
+    std::unique_lock<std::mutex> lock(mtx_);
+    msg_ = msg;
+  }
+};
+
+TEST(RealtimePublisher, rt_publish)
+{
+  const size_t ATTEMPTS = 10;
+  const std::chrono::milliseconds DELAY(250);
+
+  const char * expected_msg = "Hello World";
+  ros::NodeHandle nh;
+  const bool latching = true;
+  RealtimePublisher<std_msgs::String> rt_pub(nh, "rt_publish", 10, latching);
+  // publish a latched message
+  bool lock_is_held = rt_pub.trylock();
+  for (size_t i = 0; i < ATTEMPTS && !lock_is_held; ++i) {
+    lock_is_held = rt_pub.trylock();
+    std::this_thread::sleep_for(DELAY);
+  }
+  ASSERT_TRUE(lock_is_held);
+  rt_pub.msg_.data = expected_msg;
+  rt_pub.unlockAndPublish();
+
+  // make sure subscriber gets it
+  StringCallback str_callback;
+
+  ros::Subscriber sub = nh.subscribe("rt_publish", 10, &StringCallback::callback, &str_callback);
+  for (size_t i = 0; i < ATTEMPTS && str_callback.msg_.data.empty(); ++i)
+  {
+    ros::spinOnce();
+    std::this_thread::sleep_for(DELAY);
+  }
+  EXPECT_STREQ(expected_msg, str_callback.msg_.data.c_str());
+}
+
+int main(int argc, char ** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "realtime_publisher_tests");
+  return RUN_ALL_TESTS();
+}

--- a/test/realtime_publisher_tests.cpp
+++ b/test/realtime_publisher_tests.cpp
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include <realtime_tools/realtime_publisher.h>
 #include <std_msgs/String.h>
 #include <chrono>

--- a/test/realtime_server_goal_handle.test
+++ b/test/realtime_server_goal_handle.test
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+  <test test-name="realtime_server_goal_handle_tests" pkg="realtime_tools" type="realtime_server_goal_handle_tests" />
+</launch>

--- a/test/realtime_server_goal_handle_tests.cpp
+++ b/test/realtime_server_goal_handle_tests.cpp
@@ -62,11 +62,13 @@ struct ActionCallback
 
   bool wait_for_handle()
   {
-    for (size_t i = 0; i < ATTEMPTS; ++i) {
+    for (size_t i = 0; i < ATTEMPTS; ++i)
+    {
       ros::spinOnce();
       std::this_thread::sleep_for(DELAY);
       std::unique_lock<std::mutex> lock(mtx_);
-      if (have_handle_) {
+      if (have_handle_)
+      {
         break;
       }
     }
@@ -89,11 +91,13 @@ struct FeedbackCallback
 
   bool wait_for_feedback()
   {
-    for (size_t i = 0; i < ATTEMPTS; ++i) {
+    for (size_t i = 0; i < ATTEMPTS; ++i)
+    {
       ros::spinOnce();
       std::this_thread::sleep_for(DELAY);
       std::unique_lock<std::mutex> lock(mtx_);
-      if (have_feedback_) {
+      if (have_feedback_)
+      {
         break;
       }
     }
@@ -110,11 +114,13 @@ send_goal(
   std::shared_ptr<actionlib::SimpleActionClient<actionlib::TwoIntsAction>> ac;
   ac.reset(new actionlib::SimpleActionClient<actionlib::TwoIntsAction>(server_name, true));
 
-  for (size_t i = 0; i < ATTEMPTS && !ac->isServerConnected(); ++i) {
+  for (size_t i = 0; i < ATTEMPTS && !ac->isServerConnected(); ++i)
+  {
     ros::spinOnce();
     std::this_thread::sleep_for(DELAY);
   }
-  if (!ac->isServerConnected()) {
+  if (!ac->isServerConnected())
+  {
     ac.reset();
   } else {
     actionlib::TwoIntsGoal goal;
@@ -131,9 +137,11 @@ send_goal(
 
 bool wait_for_result(std::shared_ptr<actionlib::SimpleActionClient<actionlib::TwoIntsAction>> ac)
 {
-  for (int i = 0; i < ATTEMPTS; ++i) {
+  for (int i = 0; i < ATTEMPTS; ++i)
+  {
     ros::spinOnce();
-    if (ac->getState().isDone()) {
+    if (ac->getState().isDone())
+    {
       return true;
     }
     std::this_thread::sleep_for(DELAY);
@@ -197,7 +205,8 @@ TEST(RealtimeServerGoalHandle, set_canceled)
 
   // Cancel and wait for server to learn about that
   client->cancelGoal();
-  for (size_t i = 0; i < ATTEMPTS; ++i) {
+  for (size_t i = 0; i < ATTEMPTS; ++i)
+  {
     actionlib_msgs::GoalStatus gs = callbacks.handle_.getGoalStatus();
     if (gs.status == actionlib_msgs::GoalStatus::PREEMPTING) {
       break;

--- a/test/realtime_server_goal_handle_tests.cpp
+++ b/test/realtime_server_goal_handle_tests.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (c) 2019, Open Source Robotics Foundation, Inc.
  * All rights reserved.

--- a/test/realtime_server_goal_handle_tests.cpp
+++ b/test/realtime_server_goal_handle_tests.cpp
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include <realtime_tools/realtime_server_goal_handle.h>
 #include <actionlib/client/simple_action_client.h>
 #include <actionlib/TwoIntsAction.h>

--- a/test/realtime_server_goal_handle_tests.cpp
+++ b/test/realtime_server_goal_handle_tests.cpp
@@ -113,8 +113,7 @@ send_goal(
   const std::string & server_name,
   FeedbackCallback * cb = nullptr)
 {
-  std::shared_ptr<TwoIntsActionClient> ac;
-  ac.reset(new TwoIntsActionClient(server_name, true));
+  auto ac = std::make_shared<TwoIntsActionClient>(server_name, true);
 
   for (size_t i = 0; i < ATTEMPTS && !ac->isServerConnected(); ++i)
   {
@@ -155,11 +154,10 @@ std::shared_ptr<TwoIntsActionServer>
 make_server(const std::string & server_name, ActionCallback & callbacks)
 {
   ros::NodeHandle nh;
-  std::shared_ptr<TwoIntsActionServer> as;
-  as.reset(new TwoIntsActionServer(
+  auto as = std::make_shared<TwoIntsActionServer>(
       nh, server_name,
       boost::bind(&ActionCallback::goal_callback, &callbacks, _1),
-      boost::bind(&ActionCallback::cancel_callback, &callbacks, _1), false));
+      boost::bind(&ActionCallback::cancel_callback, &callbacks, _1), false);
   as->start();
   return as;
 }

--- a/test/realtime_server_goal_handle_tests.cpp
+++ b/test/realtime_server_goal_handle_tests.cpp
@@ -1,0 +1,281 @@
+
+/*
+ * Copyright (c) 2019, Open Source Robotics Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+#include <realtime_tools/realtime_server_goal_handle.h>
+#include <actionlib/client/simple_action_client.h>
+#include <actionlib/TwoIntsAction.h>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+using realtime_tools::RealtimeServerGoalHandle;
+
+const size_t ATTEMPTS = 10;
+const std::chrono::milliseconds DELAY(250);
+
+struct ActionCallback
+{
+  using GoalHandle = actionlib::ActionServer<actionlib::TwoIntsAction>::GoalHandle;
+  bool have_handle_ = false;
+  GoalHandle handle_;
+  std::mutex mtx_;
+
+  void goal_callback(GoalHandle handle)
+  {
+    std::unique_lock<std::mutex> lock(mtx_);
+    handle_ = handle;
+    handle_.setAccepted();
+    have_handle_ = true;
+  }
+
+  void cancel_callback(GoalHandle handle)
+  {
+  }
+
+  bool wait_for_handle()
+  {
+    for (size_t i = 0; i < ATTEMPTS; ++i) {
+      ros::spinOnce();
+      std::this_thread::sleep_for(DELAY);
+      std::unique_lock<std::mutex> lock(mtx_);
+      if (have_handle_) {
+        break;
+      }
+    }
+    std::unique_lock<std::mutex> lock(mtx_);
+    return have_handle_;
+  }
+};
+
+struct FeedbackCallback
+{
+  bool have_feedback_ = false;
+  std::mutex mtx_;
+
+  using FeedbackConstPtr = actionlib::ActionServer<actionlib::TwoIntsAction>::FeedbackConstPtr;
+  void feedback_callback(const FeedbackConstPtr &)
+  {
+    std::unique_lock<std::mutex> lock(mtx_);
+    have_feedback_ = true;
+  }
+
+  bool wait_for_feedback()
+  {
+    for (size_t i = 0; i < ATTEMPTS; ++i) {
+      ros::spinOnce();
+      std::this_thread::sleep_for(DELAY);
+      std::unique_lock<std::mutex> lock(mtx_);
+      if (have_feedback_) {
+        break;
+      }
+    }
+    std::unique_lock<std::mutex> lock(mtx_);
+    return have_feedback_;
+  }
+};
+
+std::shared_ptr<actionlib::SimpleActionClient<actionlib::TwoIntsAction>>
+send_goal(
+  const std::string & server_name,
+  FeedbackCallback * cb = nullptr)
+{
+  std::shared_ptr<actionlib::SimpleActionClient<actionlib::TwoIntsAction>> ac;
+  ac.reset(new actionlib::SimpleActionClient<actionlib::TwoIntsAction>(server_name, true));
+
+  for (size_t i = 0; i < ATTEMPTS && !ac->isServerConnected(); ++i) {
+    ros::spinOnce();
+    std::this_thread::sleep_for(DELAY);
+  }
+  if (!ac->isServerConnected()) {
+    ac.reset();
+  } else {
+    actionlib::TwoIntsGoal goal;
+    goal.a = 2;
+    goal.b = 3;
+    ac->sendGoal(
+      goal,
+      actionlib::SimpleActionClient<actionlib::TwoIntsAction>::SimpleDoneCallback(),
+      actionlib::SimpleActionClient<actionlib::TwoIntsAction>::SimpleActiveCallback(),
+      boost::bind(&FeedbackCallback::feedback_callback, cb, _1));
+  }
+  return ac;
+}
+
+bool wait_for_result(std::shared_ptr<actionlib::SimpleActionClient<actionlib::TwoIntsAction>> ac)
+{
+  for (int i = 0; i < ATTEMPTS; ++i) {
+    ros::spinOnce();
+    if (ac->getState().isDone()) {
+      return true;
+    }
+    std::this_thread::sleep_for(DELAY);
+  }
+  return false;
+}
+
+std::shared_ptr<actionlib::ActionServer<actionlib::TwoIntsAction>>
+make_server(const std::string & server_name, ActionCallback & callbacks)
+{
+  ros::NodeHandle nh;
+  std::shared_ptr<actionlib::ActionServer<actionlib::TwoIntsAction>> as;
+  as.reset(new actionlib::ActionServer<actionlib::TwoIntsAction>(
+      nh, server_name,
+      boost::bind(&ActionCallback::goal_callback, &callbacks, _1),
+      boost::bind(&ActionCallback::cancel_callback, &callbacks, _1), false));
+  as->start();
+  return as;
+}
+
+TEST(RealtimeServerGoalHandle, set_aborted)
+{
+  ActionCallback callbacks;
+  const std::string server_name("set_aborted");
+  auto as = make_server(server_name, callbacks);
+
+  auto client = send_goal(server_name);
+  ASSERT_NE(nullptr, client.get());
+
+  ASSERT_TRUE(callbacks.wait_for_handle());
+  RealtimeServerGoalHandle<actionlib::TwoIntsAction> rt_handle(callbacks.handle_);
+  ASSERT_TRUE(rt_handle.valid());
+
+  {
+    actionlib::TwoIntsResult::Ptr result(new actionlib::TwoIntsResult);
+    result->sum = 42;
+    rt_handle.setAborted(result);
+    rt_handle.runNonRealtime(ros::TimerEvent());
+  }
+
+  ASSERT_TRUE(wait_for_result(client));
+  auto state = client->getState();
+  EXPECT_EQ(state, actionlib::SimpleClientGoalState::ABORTED) << state.toString();
+  auto result = client->getResult();
+  ASSERT_NE(nullptr, result.get());
+  EXPECT_EQ(42, result->sum);
+}
+
+TEST(RealtimeServerGoalHandle, set_canceled)
+{
+  ActionCallback callbacks;
+  const std::string server_name("set_canceled");
+  auto as = make_server(server_name, callbacks);
+
+  auto client = send_goal(server_name);
+  ASSERT_NE(nullptr, client.get());
+
+  ASSERT_TRUE(callbacks.wait_for_handle());
+  RealtimeServerGoalHandle<actionlib::TwoIntsAction> rt_handle(callbacks.handle_);
+  ASSERT_TRUE(rt_handle.valid());
+
+  // Cancel and wait for server to learn about that
+  client->cancelGoal();
+  for (size_t i = 0; i < ATTEMPTS; ++i) {
+    actionlib_msgs::GoalStatus gs = callbacks.handle_.getGoalStatus();
+    if (gs.status == actionlib_msgs::GoalStatus::PREEMPTING) {
+      break;
+    }
+    ros::spinOnce();
+    std::this_thread::sleep_for(DELAY);
+  }
+  ASSERT_EQ(callbacks.handle_.getGoalStatus().status, actionlib_msgs::GoalStatus::PREEMPTING);
+
+  {
+    actionlib::TwoIntsResult::Ptr result(new actionlib::TwoIntsResult);
+    result->sum = 1234;
+    rt_handle.setCanceled(result);
+    rt_handle.runNonRealtime(ros::TimerEvent());
+  }
+
+  ASSERT_TRUE(wait_for_result(client));
+  auto state = client->getState();
+  EXPECT_EQ(state, actionlib::SimpleClientGoalState::PREEMPTED) << state.toString();
+  auto result = client->getResult();
+  ASSERT_NE(nullptr, result.get());
+  EXPECT_EQ(1234, result->sum);
+}
+
+TEST(RealtimeServerGoalHandle, set_succeeded)
+{
+  ActionCallback callbacks;
+  const std::string server_name("set_succeeded");
+  auto as = make_server(server_name, callbacks);
+
+  auto client = send_goal(server_name);
+  ASSERT_NE(nullptr, client.get());
+
+  ASSERT_TRUE(callbacks.wait_for_handle());
+  RealtimeServerGoalHandle<actionlib::TwoIntsAction> rt_handle(callbacks.handle_);
+  ASSERT_TRUE(rt_handle.valid());
+
+  {
+    actionlib::TwoIntsResult::Ptr result(new actionlib::TwoIntsResult);
+    result->sum = 321;
+    rt_handle.setSucceeded(result);
+    rt_handle.runNonRealtime(ros::TimerEvent());
+  }
+
+  ASSERT_TRUE(wait_for_result(client));
+  auto state = client->getState();
+  EXPECT_EQ(state, actionlib::SimpleClientGoalState::SUCCEEDED) << state.toString();
+  auto result = client->getResult();
+  ASSERT_NE(nullptr, result.get());
+  EXPECT_EQ(321, result->sum);
+}
+
+TEST(RealtimeServerGoalHandle, send_feedback)
+{
+  ActionCallback callbacks;
+  FeedbackCallback client_callbacks;
+  const std::string server_name("send_feedback");
+  auto as = make_server(server_name, callbacks);
+
+  auto client = send_goal(server_name, &client_callbacks);
+  ASSERT_NE(nullptr, client.get());
+
+  ASSERT_TRUE(callbacks.wait_for_handle());
+  RealtimeServerGoalHandle<actionlib::TwoIntsAction> rt_handle(callbacks.handle_);
+  ASSERT_TRUE(rt_handle.valid());
+
+  {
+    actionlib::TwoIntsFeedback::Ptr fb(new actionlib::TwoIntsFeedback());
+    rt_handle.setFeedback(fb);
+    rt_handle.runNonRealtime(ros::TimerEvent());
+  }
+
+  EXPECT_TRUE(client_callbacks.wait_for_feedback());
+}
+
+int main(int argc, char ** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "realtime_server_goal_handle_tests");
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This PR adds unit tests to make sure stuff doesn't get broken while porting to ROS 2 (#35). Also included is a fix for a race condition where `RealtimePublisher` may not publish the first message. The unit test needs this fix to pass reliably.

`RealtimePublisher` initialized `turn_` with `REALTIME`, and `publishingLoop()` also sets `turn_` to `REALTIME`. If `unblockAndPublish()` is called before before the publishing thread gets scheduled then the first message won't be published because `turn_` is overwritten. This fixes the issue by initializing `turn_` to a new state `LOOP_NOT_STARTED`. This prevents `trylock()` from returning `true` because the state is not `REALTIME`, which means there is no message to get lost.