### PR TITLE
Package format 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(realtime_tools)
 
 # Load catkin and all dependencies required for this package
-find_package(catkin REQUIRED COMPONENTS roscpp rospy)
+find_package(catkin REQUIRED COMPONENTS roscpp)
 
 find_package(Boost COMPONENTS thread)
 
@@ -10,7 +10,7 @@ include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
 
 # Declare catkin package
 catkin_package(
-  CATKIN_DEPENDS roscpp rospy
+  CATKIN_DEPENDS roscpp
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
   )

--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,6 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>roscpp</depend>
-  <depend>rospy</depend>
 
   <build_export_depend>actionlib</build_export_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -2,15 +2,7 @@
   <name>realtime_tools</name>
   <version>1.13.1</version>
   <description>Contains a set of tools that can be used from a hard
-    realtime thread, without breaking the realtime behavior.  The
-    tools currently only provides the realtime publisher, which makes
-    it possible to publish messages to a ROS topic from a realtime
-    thread. We plan to add a basic implementation of a realtime
-    buffer, to make it possible to get data from a (non-realtime)
-    topic callback into the realtime loop. Once the lockfree buffer is
-    created, the realtime publisher will start using it, which will
-    result in major API changes for the realtime publisher (removal of
-    all lock methods).</description>
+    realtime thread, without breaking the realtime behavior.</description>
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
   <maintainer email="gennaro.raiola@iit.it">Gennaro Raiola</maintainer>
 

--- a/package.xml
+++ b/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>realtime_tools</name>
   <version>1.13.1</version>
   <description>Contains a set of tools that can be used from a hard
@@ -24,10 +24,9 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>roscpp</build_depend> 
-  <build_depend>rospy</build_depend> 
+  <depend>roscpp</depend>
+  <depend>rospy</depend>
 
-  <run_depend>roscpp</run_depend> 
-  <run_depend>rospy</run_depend> 
+  <build_export_depend>actionlib</build_export_depend>
 
 </package>


### PR DESCRIPTION
~~Please review #37 first. I'll rebase this once #37 is through the review processes. The only file changed by this PR is `package.xml`~~ Edit: Changed my mind, it looks like this can go in without creating a merge conflict with #37 so this PR is ready to be reviewed

This PR
* Updates the `package.xml` to use format 2
* Adds a `<build_export_depend>` for `actionlib` since its headers are included by headers installed by this package
* Shortens the package.xml description since it appeared to be out of date


This is a step towards #35