### PR TITLE
Remove boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ project(realtime_tools)
 find_package(catkin REQUIRED COMPONENTS roscpp)
 find_package(Threads REQUIRED)
 
+find_package(Boost REQUIRED)
+
 include_directories(include)
 
 # Declare catkin package
@@ -15,8 +17,8 @@ catkin_package(
   )
 
 add_library(${PROJECT_NAME} src/realtime_clock.cpp)
-target_link_libraries(${PROJECT_NAME} PUBLIC ${catkin_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-target_include_directories(${PROJECT_NAME} PUBLIC ${catkin_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} PUBLIC ${catkin_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${Boost_LIBRARIES})
+target_include_directories(${PROJECT_NAME} PUBLIC ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
 # Unit Tests
 if (CATKIN_ENABLE_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,9 @@ project(realtime_tools)
 
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS roscpp)
+find_package(Threads REQUIRED)
 
-find_package(Boost COMPONENTS thread)
-
-include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
+include_directories(include)
 
 # Declare catkin package
 catkin_package(
@@ -16,7 +15,8 @@ catkin_package(
   )
 
 add_library(${PROJECT_NAME} src/realtime_clock.cpp)
-target_link_libraries(${PROJECT_NAME} PUBLIC ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} PUBLIC ${catkin_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_include_directories(${PROJECT_NAME} PUBLIC ${catkin_INCLUDE_DIRS})
 
 # Unit Tests
 if (CATKIN_ENABLE_TESTING)

--- a/include/realtime_tools/realtime_box.h
+++ b/include/realtime_tools/realtime_box.h
@@ -32,9 +32,8 @@
 #ifndef REALTIME_TOOLS__REALTIME_BOX_H__
 #define REALTIME_TOOLS__REALTIME_BOX_H__
 
+#include <mutex>
 #include <string>
-#include <boost/thread/mutex.hpp>
-#include <boost/thread/thread.hpp>
 
 namespace realtime_tools {
 
@@ -54,13 +53,13 @@ public:
 
   void set(const T &value)
   {
-    boost::mutex::scoped_lock guard(thing_lock_RT_);
+    std::lock_guard<std::mutex> guard(thing_lock_RT_);
     thing_ = value;
   }
 
   void get(T &ref)
   {
-    boost::mutex::scoped_lock guard(thing_lock_RT_);
+    std::lock_guard<std::mutex> guard(thing_lock_RT_);
     ref = thing_;
   }
 
@@ -73,7 +72,7 @@ private:
   // copy, so as long as the copy is realtime safe and the OS has
   // priority inheritance for mutexes, this lock can be safely locked
   // from within realtime.
-  boost::mutex thing_lock_RT_;
+  std::mutex thing_lock_RT_;
 };
 
 } // namespace

--- a/include/realtime_tools/realtime_buffer.h
+++ b/include/realtime_tools/realtime_buffer.h
@@ -39,8 +39,8 @@
 #ifndef REALTIME_TOOLS__REALTIME_BUFFER_H_
 #define REALTIME_TOOLS__REALTIME_BUFFER_H_
 
-#include <boost/thread/mutex.hpp>
 #include <chrono>
+#include <mutex>
 #include <thread>
 
 namespace realtime_tools
@@ -105,7 +105,8 @@ class RealtimeBuffer
   T* readFromRT()
   {
     // Check if the data is currently being written to (is locked)
-    if (mutex_.try_lock())
+    std::unique_lock<std::mutex> guard(mutex_, std::try_to_lock);
+    if (guard.owns_lock())
     {
       // swap pointers
       if (new_data_available_)
@@ -115,14 +116,13 @@ class RealtimeBuffer
         non_realtime_data_ = tmp;
 	new_data_available_ = false;
       }
-      mutex_.unlock();
     }
     return realtime_data_;
   }
 
   T* readFromNonRT() const
   {
-    boost::mutex::scoped_lock lock(mutex_);
+    std::lock_guard<std::mutex> guard(mutex_);
 
     if (new_data_available_)
       return non_realtime_data_;
@@ -132,15 +132,19 @@ class RealtimeBuffer
 
   void writeFromNonRT(const T& data)
   {
-    // get lock
-    lock();
+#ifdef NON_POLLING
+    std::lock_guard<std::mutex> guard(mutex_);
+#else
+    std::unique_lock<std::mutex> guard(mutex_, std::try_to_lock);
+    while (!guard.owns_lock()) {
+      std::this_thread::sleep_for(std::chrono::microseconds(500));
+      guard.try_lock();
+    }
+#endif
 
     // copy data into non-realtime buffer
     *non_realtime_data_ = data;
     new_data_available_ = true;
-
-    // release lock
-    mutex_.unlock();
   }
 
   void initRT(const T& data)
@@ -150,24 +154,13 @@ class RealtimeBuffer
   }
 
  private:
-  void lock()
-  {
-#ifdef NON_POLLING
-    mutex_.lock();
-#else
-    while (!mutex_.try_lock())
-    {
-      std::this_thread::sleep_for(std::chrono::microseconds(500));
-    }
-#endif
-  }
 
   T* realtime_data_;
   T* non_realtime_data_;
   bool new_data_available_;
 
   // Set as mutable so that readFromNonRT() can be performed on a const buffer
-  mutable boost::mutex mutex_;
+  mutable std::mutex mutex_;
 
 }; // class
 }// namespace

--- a/include/realtime_tools/realtime_clock.h
+++ b/include/realtime_tools/realtime_clock.h
@@ -39,9 +39,10 @@
 #ifndef REALTIME_TOOLS__REALTIME_CLOCK_H_
 #define REALTIME_TOOLS__REALTIME_CLOCK_H_
 
-#include <boost/thread/mutex.hpp>
-#include <boost/thread.hpp>
 #include <ros/ros.h>
+
+#include <mutex>
+#include <thread>
 
 namespace realtime_tools
 {
@@ -57,16 +58,14 @@ class RealtimeClock
 
 
  private:
-  void lock();
-
   unsigned int lock_misses_;
   ros::Time system_time_;
   ros::Duration clock_offset_;
 
   ros::Time last_realtime_time_;
   bool running_, initialized_;
-  boost::mutex mutex_;
-  boost::thread thread_;
+  std::mutex mutex_;
+  std::thread thread_;
 
 
 

--- a/include/realtime_tools/realtime_clock.h
+++ b/include/realtime_tools/realtime_clock.h
@@ -58,12 +58,13 @@ class RealtimeClock
 
 
  private:
-  unsigned int lock_misses_;
+  unsigned int lock_misses_ = 0;
   ros::Time system_time_;
   ros::Duration clock_offset_;
 
   ros::Time last_realtime_time_;
-  bool running_, initialized_;
+  bool running_ = false;
+  bool initialized_ = false;
   std::mutex mutex_;
   std::thread thread_;
 

--- a/include/realtime_tools/realtime_publisher.h
+++ b/include/realtime_tools/realtime_publisher.h
@@ -40,17 +40,15 @@
 
 #include <string>
 #include <ros/node_handle.h>
-#include <boost/utility.hpp>
-#include <boost/thread/mutex.hpp>
-#include <boost/thread/thread.hpp>
-#include <boost/thread/condition.hpp>
 #include <chrono>
+#include <condition_variable>
+#include <mutex>
 #include <thread>
 
 namespace realtime_tools {
 
 template <class Msg>
-class RealtimePublisher : boost::noncopyable
+class RealtimePublisher
 {
 
 public:
@@ -83,7 +81,7 @@ public:
     {
       std::this_thread::sleep_for(std::chrono::microseconds(100));
     }
-
+    thread_.join();
     publisher_.shutdown();
   }
 
@@ -172,11 +170,15 @@ public:
   }
 
 private:
+  // non-copyable
+  RealtimePublisher(const RealtimePublisher &) = delete;
+  RealtimePublisher & operator=(const RealtimePublisher &) = delete;
+
   void construct(int queue_size, bool latched=false)
   {
     publisher_ = node_.advertise<Msg>(topic_, queue_size, latched);
     keep_running_ = true;
-    thread_ = boost::thread(&RealtimePublisher::publishingLoop, this);
+    thread_ = std::thread(&RealtimePublisher::publishingLoop, this);
   }
 
 
@@ -221,12 +223,12 @@ private:
   volatile bool is_running_;
   volatile bool keep_running_;
 
-  boost::thread thread_;
+  std::thread thread_;
 
-  boost::mutex msg_mutex_;  // Protects msg_
+  std::mutex msg_mutex_;  // Protects msg_
 
 #ifdef NON_POLLING
-  boost::condition_variable updated_cond_;
+  std::condition_variable updated_cond_;
 #endif
 
   enum {REALTIME, NON_REALTIME, LOOP_NOT_STARTED};

--- a/include/realtime_tools/realtime_publisher.h
+++ b/include/realtime_tools/realtime_publisher.h
@@ -42,6 +42,7 @@
 #include <ros/node_handle.h>
 #include <chrono>
 #include <condition_variable>
+#include <memory>
 #include <mutex>
 #include <thread>
 
@@ -235,7 +236,6 @@ private:
   int turn_;  // Who's turn is it to use msg_?
 };
 
-#include <memory>
 template <class Msg>
 using RealtimePublisherSharedPtr = std::shared_ptr<RealtimePublisher<Msg> >;
 

--- a/include/realtime_tools/realtime_server_goal_handle.h
+++ b/include/realtime_tools/realtime_server_goal_handle.h
@@ -46,8 +46,8 @@ private:
   ACTION_DEFINITION(Action);
 
   typedef actionlib::ServerGoalHandle<Action> GoalHandle;
-  typedef boost::shared_ptr<Result> ResultPtr;
-  typedef boost::shared_ptr<Feedback> FeedbackPtr;
+  typedef std::shared_ptr<Result> ResultPtr;
+  typedef std::shared_ptr<Feedback> FeedbackPtr;
 
   uint8_t state_;
 

--- a/include/realtime_tools/realtime_server_goal_handle.h
+++ b/include/realtime_tools/realtime_server_goal_handle.h
@@ -33,6 +33,8 @@
 // Standard
 #include <memory>
 
+#include <boost/shared_ptr.hpp>
+
 // Actionlib
 #include <actionlib/server/action_server.h>
 
@@ -46,8 +48,8 @@ private:
   ACTION_DEFINITION(Action);
 
   typedef actionlib::ServerGoalHandle<Action> GoalHandle;
-  typedef std::shared_ptr<Result> ResultPtr;
-  typedef std::shared_ptr<Feedback> FeedbackPtr;
+  typedef boost::shared_ptr<Result> ResultPtr;
+  typedef boost::shared_ptr<Feedback> FeedbackPtr;
 
   uint8_t state_;
 

--- a/src/realtime_clock.cpp
+++ b/src/realtime_clock.cpp
@@ -44,11 +44,7 @@ namespace realtime_tools
 
   
   RealtimeClock::RealtimeClock()
-    :lock_misses_(0), 
-     system_time_(ros::Time()), 
-     last_realtime_time_(ros::Time()),
-     running_(true),
-     initialized_(false),
+    : running_(true),
      thread_(std::thread(&RealtimeClock::loop, this))
   {
   }

--- a/test/realtime_server_goal_handle_tests.cpp
+++ b/test/realtime_server_goal_handle_tests.cpp
@@ -158,7 +158,7 @@ make_server(const std::string & server_name, ActionCallback & callbacks)
   auto as = std::make_shared<TwoIntsActionServer>(
       nh, server_name,
       std::bind(&ActionCallback::goal_callback, &callbacks, std::placeholders::_1),
-      std::bind(&ActionCallback::cancel_callback, &callbacks, std::placeholders::_1), false));
+      std::bind(&ActionCallback::cancel_callback, &callbacks, std::placeholders::_1), false);
   as->start();
   return as;
 }

--- a/test/realtime_server_goal_handle_tests.cpp
+++ b/test/realtime_server_goal_handle_tests.cpp
@@ -32,6 +32,7 @@
 #include <actionlib/client/simple_action_client.h>
 #include <actionlib/TwoIntsAction.h>
 #include <chrono>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <thread>
@@ -131,7 +132,7 @@ send_goal(
       goal,
       TwoIntsActionClient::SimpleDoneCallback(),
       TwoIntsActionClient::SimpleActiveCallback(),
-      boost::bind(&FeedbackCallback::feedback_callback, cb, _1));
+      std::bind(&FeedbackCallback::feedback_callback, cb, std::placeholders::_1));
   }
   return ac;
 }
@@ -156,8 +157,8 @@ make_server(const std::string & server_name, ActionCallback & callbacks)
   ros::NodeHandle nh;
   auto as = std::make_shared<TwoIntsActionServer>(
       nh, server_name,
-      boost::bind(&ActionCallback::goal_callback, &callbacks, _1),
-      boost::bind(&ActionCallback::cancel_callback, &callbacks, _1), false);
+      std::bind(&ActionCallback::goal_callback, &callbacks, std::placeholders::_1),
+      std::bind(&ActionCallback::cancel_callback, &callbacks, std::placeholders::_1), false));
   as->start();
   return as;
 }


### PR DESCRIPTION
This removes all uses of boost. This PR depends on #37. I'll rebase this one once that's through the review process.

This change probably breaks ABI (changes the size of `RealtimeClock`), so it should be targeted at a `noetic-devel` branch.

This is a step towards #35