### PR TITLE
Remove actionlib definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,6 @@ project(realtime_tools)
 find_package(catkin REQUIRED COMPONENTS roscpp)
 find_package(Threads REQUIRED)
 
-find_package(Boost REQUIRED)
-
 include_directories(include)
 
 # Declare catkin package
@@ -17,8 +15,8 @@ catkin_package(
   )
 
 add_library(${PROJECT_NAME} src/realtime_clock.cpp)
-target_link_libraries(${PROJECT_NAME} PUBLIC ${catkin_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${Boost_LIBRARIES})
-target_include_directories(${PROJECT_NAME} PUBLIC ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} PUBLIC ${catkin_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_include_directories(${PROJECT_NAME} PUBLIC ${catkin_INCLUDE_DIRS})
 
 # Unit Tests
 if (CATKIN_ENABLE_TESTING)

--- a/include/realtime_tools/realtime_server_goal_handle.h
+++ b/include/realtime_tools/realtime_server_goal_handle.h
@@ -33,8 +33,6 @@
 // Standard
 #include <memory>
 
-#include <boost/shared_ptr.hpp>
-
 // Actionlib
 #include <actionlib/server/action_server.h>
 
@@ -48,8 +46,6 @@ private:
   ACTION_DEFINITION(Action);
 
   typedef actionlib::ServerGoalHandle<Action> GoalHandle;
-  typedef boost::shared_ptr<Result> ResultPtr;
-  typedef boost::shared_ptr<Feedback> FeedbackPtr;
 
   uint8_t state_;
 


### PR DESCRIPTION
Follow up from #39. This removes actionlib typedefs. It should be merged after ros/actionlib#145 is released into melodic.