### PR TITLE
Fix building realtime_publisher using NON_POLLING

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+# Travis Continuous Integration Configuration File For ROS Control Projects
+language: generic
+services:
+  - docker
+
+notifications:
+  email:
+    recipients:
+      - enrique.fernandez.perdomo@gmail.com
+      - bence.magyar.robotics@gmail.com
+      - gennaro.raiola@gmail.com
+    on_success: change #[always|never|change] # default: change
+    on_failure: change #[always|never|change] # default: always
+
+env:
+  global:
+    - UPSTREAM_WORKSPACE='https://raw.github.com/ros-controls/ros_control/$ROS_DISTRO-devel/ros_control.rosinstall -realtime_tools'
+  matrix:
+    - ROS_DISTRO=melodic ROS_REPO=ros
+    - ROS_DISTRO=melodic ROS_REPO=ros-testing
+
+install:
+  - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci -b master
+script:
+- .industrial_ci/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ services:
 notifications:
   email:
     recipients:
-      - enrique.fernandez.perdomo@gmail.com
       - bence.magyar.robotics@gmail.com
-      - gennaro.raiola@gmail.com
     on_success: change #[always|never|change] # default: change
     on_failure: change #[always|never|change] # default: always
 

--- a/include/realtime_tools/realtime_buffer.h
+++ b/include/realtime_tools/realtime_buffer.h
@@ -51,7 +51,6 @@ class RealtimeBuffer
 {
  public:
   RealtimeBuffer()
-    : new_data_available_(false)
   {
     // allocate memory
     non_realtime_data_ = new T();
@@ -157,7 +156,7 @@ class RealtimeBuffer
 
   T* realtime_data_;
   T* non_realtime_data_;
-  bool new_data_available_;
+  bool new_data_available_{false};
 
   // Set as mutable so that readFromNonRT() can be performed on a const buffer
   mutable std::mutex mutex_;

--- a/include/realtime_tools/realtime_publisher.h
+++ b/include/realtime_tools/realtime_publisher.h
@@ -124,7 +124,7 @@ public:
       }
       else
       {
-        msg_mutex_.unlock();
+        unlock();
         return false;
       }
     }
@@ -143,10 +143,7 @@ public:
   void unlockAndPublish()
   {
     turn_ = NON_REALTIME;
-    msg_mutex_.unlock();
-#ifdef NON_POLLING
-    updated_cond_.notify_one();
-#endif
+    unlock();
   }
 
   /**  \brief Get the data lock form non-realtime
@@ -174,6 +171,9 @@ public:
   void unlock()
   {
     msg_mutex_.unlock();
+#ifdef NON_POLLING
+    updated_cond_.notify_one();
+#endif
   }
 
 private:
@@ -188,13 +188,15 @@ private:
     thread_ = std::thread(&RealtimePublisher::publishingLoop, this);
   }
 
-
   bool is_running() const { return is_running_; }
 
   void publishingLoop()
   {
     is_running_ = true;
     turn_ = REALTIME;
+#ifdef NON_POLLING
+    std::unique_lock<std::mutex> cond_lock_(msg_mutex_, std::defer_lock_t());
+#endif
 
     while (keep_running_)
     {
@@ -205,7 +207,7 @@ private:
       while (turn_ != NON_REALTIME && keep_running_)
       {
 #ifdef NON_POLLING
-        updated_cond_.wait(lock);
+        updated_cond_.wait(cond_lock_);
 #else
         unlock();
         std::this_thread::sleep_for(std::chrono::microseconds(500));

--- a/src/realtime_clock.cpp
+++ b/src/realtime_clock.cpp
@@ -117,7 +117,9 @@ namespace realtime_tools
 	ROS_WARN_THROTTLE(1.0, "Time estimator has trouble transferring data between non-RT and RT");
 
       // release lock
+#ifndef NON_POLLING
       guard.unlock();
+#endif
       r.sleep();
     }
   }


### PR DESCRIPTION
An update from my previous PR since a lot has been improved since then. This should isolate it to just the fixes to get NON_POLLING to build.

Previously this tried wait on a condition variable using the lock() method as an argument. That didn't build because wait() expects a lock_guard<mutex> rather than a class method. This commit adds a lock_guard as a local var to the publisher loop and uses it to wait when NON_POLLING is defined. 

Additionally, it updates code to call the unlock() method in various places to pick up conditional calls to       the condition var's notify_one() to wake up the cv's wait().
