### PR TITLE
Check whether thread joinable before joining

### DIFF
--- a/include/realtime_tools/realtime_publisher.h
+++ b/include/realtime_tools/realtime_publisher.h
@@ -82,7 +82,11 @@ public:
     {
       std::this_thread::sleep_for(std::chrono::microseconds(100));
     }
-    thread_.join();
+
+    if (thread_.joinable())
+    {
+      thread_.join();
+    }
     publisher_.shutdown();
   }
 


### PR DESCRIPTION
Current when `RealtimePublisher` is constructed with default constructor and `init` function is never called, joining an "empty" thread will cause exception. 

This PR checks whether the thread is joinable before joining.