### PR TITLE
Use std::atomic instead of volatile

### DIFF
--- a/include/realtime_tools/realtime_publisher.h
+++ b/include/realtime_tools/realtime_publisher.h
@@ -205,8 +205,8 @@ private:
   }
 
   PublisherSharedPtr publisher_;
-  std::atomic_bool is_running_;
-  std::atomic_bool keep_running_;
+  std::atomic<bool> is_running_;
+  std::atomic<bool> keep_running_;
 
   std::thread thread_;
 
@@ -217,7 +217,7 @@ private:
 #endif
 
   enum {REALTIME, NON_REALTIME, LOOP_NOT_STARTED};
-  int turn_;  // Who's turn is it to use msg_?
+  std::atomic<int> turn_;  // Who's turn is it to use msg_?
 };
 
 template <class Msg>

--- a/include/realtime_tools/realtime_publisher.h
+++ b/include/realtime_tools/realtime_publisher.h
@@ -38,6 +38,7 @@
 #ifndef REALTIME_TOOLS__REALTIME_PUBLISHER_H_
 #define REALTIME_TOOLS__REALTIME_PUBLISHER_H_
 
+#include <atomic>
 #include <string>
 #include <rclcpp/publisher.hpp>
 #include <chrono>
@@ -204,8 +205,8 @@ private:
   }
 
   PublisherSharedPtr publisher_;
-  volatile bool is_running_;
-  volatile bool keep_running_;
+  std::atomic_bool is_running_;
+  std::atomic_bool keep_running_;
 
   std::thread thread_;
 


### PR DESCRIPTION
C++11 has `std::atomic` for atomic variable. This PR uses it instead of classical `volatile` variable.