### PR TITLE
check for gmock before testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC ${catkin_LIBRARIES} ${CMAKE_THREAD_
 target_include_directories(${PROJECT_NAME} PUBLIC ${catkin_INCLUDE_DIRS})
 
 # Unit Tests
-if (CATKIN_ENABLE_TESTING)
+if (CATKIN_ENABLE_TESTING AND (EXISTS ${GMOCK_MAIN_LIBRARIES}))
   catkin_add_gmock(realtime_box_tests test/realtime_box_tests.cpp)
   target_link_libraries(realtime_box_tests ${PROJECT_NAME} ${GMOCK_MAIN_LIBRARIES})
 


### PR DESCRIPTION
Due to some bug in either ArchLinux gtest/gmock packaging or catkin (still not sure where) `realtime_box_tests` is not able to build and causes a build error on ArchLinux systems.
In this repo, the flag `CATKIN_ENABLE_TESTING` is set to True even if `${GMOCK_MAIN_LIBRARIES}` does not exist. If `GMOCK_MAIN_LIBRARIES` is empty then the build will fail, instead of just completing without performing unit tests.

This PR creates a check for GMOCK_MAIN_LIBRARIES so that even if `CATKIN_ENABLE_TESTING` is true the tests will only go through if GMOCK_MAIN_LIBRARIES exist as well.

Relevant discussions: #44 here in this repo
https://github.com/ros/catkin/issues/1030   issue at catkin and
https://github.com/ros-melodic-arch/ros-melodic-realtime-tools/issues/1 at ArchLinux packaging.