### PR TITLE
Fix the mis-type error in realtime_server_goal_handle.h

### DIFF
--- a/include/realtime_tools/realtime_server_goal_handle.h
+++ b/include/realtime_tools/realtime_server_goal_handle.h
@@ -164,7 +164,7 @@ public:
       }
     } catch (const rclcpp::exceptions::RCLErrorBase & e) {
       // Likely invalid state transition
-      RCLCPP_WARN(logger_, e.formatted_message);
+      RCLCPP_WARN(logger_, "%s", e.formatted_message.c_str());
     }
   }
 };


### PR DESCRIPTION
This pull request is attempting to fix the CI failure seen here https://github.com/ros-controls/control_toolbox/pull/103.

```
2021-01-04T20:36:46.7269161Z                  from /home/runner/work/control_toolbox/control_toolbox/ros_ws/src/realtime_tools/test/realtime_server_goal_handle_tests.cpp:39:
2021-01-04T20:36:46.7271407Z /home/runner/work/control_toolbox/control_toolbox/ros_ws/src/realtime_tools/include/realtime_tools/realtime_server_goal_handle.h: In member function ‘void realtime_tools::RealtimeServerGoalHandle<Action>::runNonRealtime()’:
2021-01-04T20:36:46.7274284Z /home/runner/work/control_toolbox/control_toolbox/ros_ws/src/realtime_tools/include/realtime_tools/realtime_server_goal_handle.h:167:7: error: cannot convert ‘const string {aka const std::__cxx11::basic_string<char>}’ to ‘const char*’ for argument ‘4’ to ‘void rcutils_log(const rcutils_log_location_t*, int, const char*, const char*, ...)’
2021-01-04T20:36:46.7275836Z        RCLCPP_WARN(logger_, e.formatted_message);
2021-01-04T20:36:46.7276305Z        ^
2021-01-04T20:36:46.7277022Z make[2]: *** [CMakeFiles/realtime_server_goal_handle_tests.dir/test/realtime_server_goal_handle_tests.cpp.o] Error 1
2021-01-04T20:36:46.7277988Z make[1]: *** [CMakeFiles/realtime_server_goal_handle_tests.dir/all] Error 2
```