### PR TITLE
Accommodate the RCLCPP_WARN macro by using a C string

### DIFF
--- a/include/realtime_tools/realtime_server_goal_handle.h
+++ b/include/realtime_tools/realtime_server_goal_handle.h
@@ -164,7 +164,7 @@ public:
       }
     } catch (const rclcpp::exceptions::RCLErrorBase & e) {
       // Likely invalid state transition
-      RCLCPP_WARN(logger_, e.formatted_message);
+      RCLCPP_WARN(logger_, e.formatted_message.c_str());
     }
   }
 };


### PR DESCRIPTION
Fix a compile-time issue with the latest ROS 2 code.

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>