### PR TITLE
Add a library to detect a realtime kernel and set thread priority

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,10 +18,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC include)
 
 # A library to detect a realtime kernel and set thread priority, if one is found
 add_library(thread_priority STATIC src/thread_priority.cpp)
-target_include_directories(thread_priority PUBLIC
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>"
-)
+target_include_directories(thread_priority PUBLIC include)
 ament_target_dependencies(thread_priority ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 # Unit Tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,14 @@ ament_target_dependencies(${PROJECT_NAME} "rclcpp" "rclcpp_action")
 target_link_libraries(${PROJECT_NAME} ${CMAKE_THREAD_LIBS_INIT})
 target_include_directories(${PROJECT_NAME} PUBLIC include)
 
+# A library to detect a realtime kernel and set thread priority, if one is found
+add_library(thread_priority STATIC src/thread_priority.cpp)
+target_include_directories(thread_priority PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>"
+)
+ament_target_dependencies(thread_priority ${THIS_PACKAGE_INCLUDE_DEPENDS})
+
 # Unit Tests
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
@@ -44,13 +52,13 @@ install(
   DIRECTORY include/
   DESTINATION include)
 
-install(TARGETS ${PROJECT_NAME}
+install(TARGETS ${PROJECT_NAME} thread_priority
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)
 
 ament_export_include_directories(include)
-ament_export_libraries(${PROJECT_NAME})
+ament_export_libraries(${PROJECT_NAME} thread_priority)
 
 ament_export_dependencies(rclcpp)
 ament_export_dependencies(rclcpp_action)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,13 +13,13 @@ find_package(Threads REQUIRED)
 
 add_library(${PROJECT_NAME} src/realtime_clock.cpp)
 ament_target_dependencies(${PROJECT_NAME} "rclcpp" "rclcpp_action")
-target_link_libraries(${PROJECT_NAME} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${PROJECT_NAME} ${Update CMakeLists.txt})
 target_include_directories(${PROJECT_NAME} PUBLIC include)
 
 # A library to detect a realtime kernel and set thread priority, if one is found
 add_library(thread_priority STATIC src/thread_priority.cpp)
 target_include_directories(thread_priority PUBLIC include)
-ament_target_dependencies(thread_priority ${THIS_PACKAGE_INCLUDE_DEPENDS})
+ament_target_dependencies(thread_priority "rclcpp" "rclcpp_action")
 
 # Unit Tests
 if(BUILD_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(Threads REQUIRED)
 
 add_library(${PROJECT_NAME} src/realtime_clock.cpp)
 ament_target_dependencies(${PROJECT_NAME} "rclcpp" "rclcpp_action")
-target_link_libraries(${PROJECT_NAME} ${Update CMakeLists.txt})
+target_link_libraries(${PROJECT_NAME} ${CMAKE_THREAD_LIBS_INIT})
 target_include_directories(${PROJECT_NAME} PUBLIC include)
 
 # A library to detect a realtime kernel and set thread priority, if one is found

--- a/include/realtime_tools/thread_priority.hpp
+++ b/include/realtime_tools/thread_priority.hpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022 PickNik Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef REALTIME_TOOLS__JOINT_THREAD_PRIORITY_HPP_
+#define REALTIME_TOOLS__JOINT_THREAD_PRIORITY_HPP_
+
+namespace realtime_tools
+{
+/**
+ * Detect if realtime kernel is present.
+ * \returns true if realtime kernel is detected
+ */
+bool has_realtime_kernel();
+
+/**
+ * Configure SCHED_FIFO thread priority for the thread that calls this function
+ * \param[in] priority the priority of this thread from 0-99
+ * \returns true if configuring scheduler succeeded
+ */
+bool configure_sched_fifo(int priority);
+
+}  // namespace realtime_tools
+
+#endif  // REALTIME_TOOLS__JOINT_THREAD_PRIORITY_HPP_

--- a/include/realtime_tools/thread_priority.hpp
+++ b/include/realtime_tools/thread_priority.hpp
@@ -10,7 +10,7 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *     * Neither the name of the PickNik Inc. nor the names of its
  *       contributors may be used to endorse or promote products derived from
  *       this software without specific prior written permission.
  *

--- a/include/realtime_tools/thread_priority.hpp
+++ b/include/realtime_tools/thread_priority.hpp
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef REALTIME_TOOLS__JOINT_THREAD_PRIORITY_HPP_
-#define REALTIME_TOOLS__JOINT_THREAD_PRIORITY_HPP_
+#ifndef REALTIME_TOOLS__THREAD_PRIORITY_HPP_
+#define REALTIME_TOOLS__THREAD_PRIORITY_HPP_
 
 namespace realtime_tools
 {
@@ -47,4 +47,4 @@ bool configure_sched_fifo(int priority);
 
 }  // namespace realtime_tools
 
-#endif  // REALTIME_TOOLS__JOINT_THREAD_PRIORITY_HPP_
+#endif  // REALTIME_TOOLS__THREAD_PRIORITY_HPP_

--- a/src/thread_priority.cpp
+++ b/src/thread_priority.cpp
@@ -10,7 +10,7 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *     * Neither the name of the PickNik Inc. nor the names of its
  *       contributors may be used to endorse or promote products derived from
  *       this software without specific prior written permission.
  *

--- a/src/thread_priority.cpp
+++ b/src/thread_priority.cpp
@@ -29,9 +29,10 @@
 
 #include "realtime_tools/thread_priority.hpp"
 
+#include <sched.h>
+
 #include <cstring>
 #include <fstream>
-#include <sched.h>
 
 namespace realtime_tools
 {

--- a/src/thread_priority.cpp
+++ b/src/thread_priority.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022 PickNik Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "realtime_tools/thread_priority.hpp"
+
+#include <cstring>
+#include <fstream>
+#include <sched.h>
+
+namespace realtime_tools
+{
+bool has_realtime_kernel()
+{
+  std::ifstream realtime_file("/sys/kernel/realtime", std::ios::in);
+  bool has_realtime = false;
+  if (realtime_file.is_open())
+  {
+    realtime_file >> has_realtime;
+  }
+  return has_realtime;
+}
+
+bool configure_sched_fifo(int priority)
+{
+  struct sched_param schedp;
+  memset(&schedp, 0, sizeof(schedp));
+  schedp.sched_priority = priority;
+  return !sched_setscheduler(0, SCHED_FIFO, &schedp);
+}
+
+}  // namespace realtime_tools


### PR DESCRIPTION
As suggested in this ros2_control PR:  https://github.com/ros-controls/ros2_control/pull/792

Add a library to detect a realtime kernel and set thread priority. Having it here should make it easy to link against from other packages and generally seems like a better place to have the library than inside `controller_manager`.