### PR TITLE
Make `thread_priority` a shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ target_link_libraries(${PROJECT_NAME} ${CMAKE_THREAD_LIBS_INIT})
 target_include_directories(${PROJECT_NAME} PUBLIC include)
 
 # A library to detect a realtime kernel and set thread priority, if one is found
-add_library(thread_priority STATIC src/thread_priority.cpp)
+add_library(thread_priority SHARED src/thread_priority.cpp)
 target_include_directories(thread_priority PUBLIC include)
 ament_target_dependencies(thread_priority "rclcpp" "rclcpp_action")
 


### PR DESCRIPTION
This library should be shared so other shared libraries can link it.

I discovered this during this PR:  https://github.com/ros-planning/moveit2/pull/1540

Note that the library I'm linking it to is another shared (aka dynamic) library.

Prior to this PR I get this error:

```
--- stderr: moveit_servo
/usr/bin/ld: /home/andy/ws_ros2/install/realtime_tools/lib/libthread_priority.a(thread_priority.cpp.o): warning: relocation against `_ZTVSt9basic_iosIcSt11char_traitsIcEE@@GLIBCXX_3.4' in read-only section `.text.unlikely'
/usr/bin/ld: /home/andy/ws_ros2/install/realtime_tools/lib/libthread_priority.a(thread_priority.cpp.o): relocation R_X86_64_PC32 against symbol `_ZTTSt14basic_ifstreamIcSt11char_traitsIcEE@@GLIBCXX_3.4' can not be used when making a shared object; recompile with -fPIC
```
---
If you don't like the idea of making the `thread_priority` library SHARED, then another way to fix it is to add this to CMakeLists:

`set(CMAKE_CXX_FLAGS "-fPIC ${CMAKE_CXX_FLAGS}")`