### PR TITLE
initialize the global context to avoid runtime_error upon destruction

### DIFF
--- a/test/realtime_clock_tests.cpp
+++ b/test/realtime_clock_tests.cpp
@@ -38,6 +38,8 @@ using realtime_tools::RealtimeClock;
 
 TEST(RealtimeClock, get_system_time)
 {
+  // initialize the global context
+  rclcpp::init(0, nullptr);
   const int ATTEMPTS = 10;
   const std::chrono::milliseconds DELAY(1);
 

--- a/test/realtime_clock_tests.cpp
+++ b/test/realtime_clock_tests.cpp
@@ -44,15 +44,18 @@ TEST(RealtimeClock, get_system_time)
   const std::chrono::milliseconds DELAY(1);
 
   rclcpp::Clock::SharedPtr clock(new rclcpp::Clock());
-  RealtimeClock rt_clock(clock);
-  // Wait for time to be available
-  rclcpp::Time last_rt_time;
-  for (int i = 0; i < ATTEMPTS && rclcpp::Time() == last_rt_time; ++i) {
-    std::this_thread::sleep_for(DELAY);
-    last_rt_time = rt_clock.now(rclcpp::Time());
-  }
-  ASSERT_NE(rclcpp::Time(), last_rt_time);
+  {
+    RealtimeClock rt_clock(clock);
+    // Wait for time to be available
+    rclcpp::Time last_rt_time;
+    for (int i = 0; i < ATTEMPTS && rclcpp::Time() == last_rt_time; ++i) {
+      std::this_thread::sleep_for(DELAY);
+      last_rt_time = rt_clock.now(rclcpp::Time());
+    }
+    ASSERT_NE(rclcpp::Time(), last_rt_time);
 
-  // This test assumes system time will not jump backwards during it
-  EXPECT_GT(rt_clock.now(last_rt_time), last_rt_time);
+    // This test assumes system time will not jump backwards during it
+    EXPECT_GT(rt_clock.now(last_rt_time), last_rt_time);
+  }
+  rclcpp::shutdown();
 }


### PR DESCRIPTION
This fixes the issue pointed by @christophfroehlich about the failing tests in the rolling that at the end of the tests upon destruction, the context becomes invalid

```
[ RUN ] RealtimeClock.get_system_time
 terminate called after throwing an instance of 'std::runtime_error'
 what(): context cannot be slept with because it's invalid
 ```