### PR TITLE
Fix ignore and patch for codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 realtime_tools
 ===========
-[![codecov](https://codecov.io/gh/ros-controls/realtime_tools/graph/badge.svg?token=Osge1FOaAh)](https://codecov.io/gh/ros-controls/realtime_tools)
+[![codecov](https://codecov.io/gh/ros-controls/realtime_tools/branch/master/graph/badge.svg?token=Osge1FOaAh)](https://app.codecov.io/gh/ros-controls/realtime_tools/tree/master)
 
 See [control.ros.org](http://control.ros.org) and [realtime_tools](http://wiki.ros.org/realtime_tools) documentation on ros.org
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,7 +10,7 @@ coverage:
 fixes:
   - "ros_ws/src/realtime_tools/::"
 ignore:
-  - "**/test"
+  - "test"
 comment:
   layout: "diff, flags, files"
   behavior: default


### PR DESCRIPTION
The default branch on codecov is "indigo-devel", I cannot change it: 

> We were unable to update the default branch for this repo

I also fixed the glob for the ignore of the test folder.