### PR TITLE
update unlock method to also include the part of the NON_POLLING

### DIFF
--- a/include/realtime_tools/realtime_publisher.h
+++ b/include/realtime_tools/realtime_publisher.h
@@ -121,10 +121,7 @@ public:
   void unlockAndPublish()
   {
     turn_ = NON_REALTIME;
-    msg_mutex_.unlock();
-#ifdef NON_POLLING
-    updated_cond_.notify_one();
-#endif
+    unlock();
   }
 
   /**  \brief Get the data lock form non-realtime
@@ -148,7 +145,13 @@ public:
   /**  \brief Unlocks the data without publishing anything
    *
    */
-  void unlock() { msg_mutex_.unlock(); }
+  void unlock()
+  {
+    msg_mutex_.unlock();
+#ifdef NON_POLLING
+    updated_cond_.notify_one();
+#endif
+  }
 
 private:
   // non-copyable


### PR DESCRIPTION
Update the `unlock` method to be similar to the noetic branch

https://github.com/ros-controls/realtime_tools/blob/164f6d8702df7f510aee5bdd7e77ceb1a251ec0f/include/realtime_tools/realtime_publisher.h#L171-L177