### PR TITLE
Include <functional> in realtime_box_best_effort

### DIFF
--- a/include/realtime_tools/realtime_box_best_effort.h
+++ b/include/realtime_tools/realtime_box_best_effort.h
@@ -31,6 +31,7 @@
 #ifndef REALTIME_TOOLS__REALTIME_BOX_BEST_EFFORT_H_
 #define REALTIME_TOOLS__REALTIME_BOX_BEST_EFFORT_H_
 
+#include <functional>
 #include <initializer_list>
 #include <mutex>
 #include <optional>


### PR DESCRIPTION
Since the `RealTimeBoxBestEffort` uses `std::function`s to set and get pointer types (which is great), it should also include `<functional>`.

Note: This doesn't explode in the tests, since there is `gmock` included, which somewhere includes <functional> on the way.