### PR TITLE
Rename thread_priority to realtime_helpers header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ ament_target_dependencies(realtime_tools PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 # A library to detect a realtime kernel and set thread priority, if one is found
 add_library(thread_priority SHARED
-  src/thread_priority.cpp
+  src/realtime_helpers.cpp
 )
 target_compile_features(thread_priority PUBLIC cxx_std_17)
 target_include_directories(thread_priority PUBLIC
@@ -39,6 +39,19 @@ target_include_directories(thread_priority PUBLIC
 ament_target_dependencies(thread_priority PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 if(UNIX)
   target_link_libraries(thread_priority PUBLIC cap)
+endif()
+
+add_library(realtime_helpers SHARED
+  src/realtime_helpers.cpp
+)
+target_compile_features(realtime_helpers PUBLIC cxx_std_17)
+target_include_directories(realtime_helpers PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/realtime_tools>
+)
+ament_target_dependencies(realtime_helpers PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
+if(UNIX)
+  target_link_libraries(realtime_helpers PUBLIC cap)
 endif()
 
 # Unit Tests
@@ -88,7 +101,7 @@ install(
   DIRECTORY include/
   DESTINATION include/realtime_tools
 )
-install(TARGETS realtime_tools thread_priority
+install(TARGETS realtime_tools realtime_helpers thread_priority
   EXPORT export_realtime_tools
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ endforeach()
 
 add_library(realtime_tools SHARED
   src/realtime_clock.cpp
+  src/realtime_helpers.cpp
 )
 target_compile_features(realtime_tools PUBLIC cxx_std_17)
 target_include_directories(realtime_tools PUBLIC
@@ -26,6 +27,9 @@ target_include_directories(realtime_tools PUBLIC
   $<INSTALL_INTERFACE:include/realtime_tools>
 )
 ament_target_dependencies(realtime_tools PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
+if(UNIX)
+  target_link_libraries(realtime_tools PUBLIC cap)
+endif()
 
 # A library to detect a realtime kernel and set thread priority, if one is found
 add_library(thread_priority SHARED
@@ -39,19 +43,6 @@ target_include_directories(thread_priority PUBLIC
 ament_target_dependencies(thread_priority PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 if(UNIX)
   target_link_libraries(thread_priority PUBLIC cap)
-endif()
-
-add_library(realtime_helpers SHARED
-  src/realtime_helpers.cpp
-)
-target_compile_features(realtime_helpers PUBLIC cxx_std_17)
-target_include_directories(realtime_helpers PUBLIC
-  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include/realtime_tools>
-)
-ament_target_dependencies(realtime_helpers PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
-if(UNIX)
-  target_link_libraries(realtime_helpers PUBLIC cap)
 endif()
 
 # Unit Tests
@@ -101,7 +92,7 @@ install(
   DIRECTORY include/
   DESTINATION include/realtime_tools
 )
-install(TARGETS realtime_tools realtime_helpers thread_priority
+install(TARGETS realtime_tools thread_priority
   EXPORT export_realtime_tools
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib

--- a/include/realtime_tools/async_function_handler.hpp
+++ b/include/realtime_tools/async_function_handler.hpp
@@ -32,7 +32,7 @@
 #include "rclcpp/duration.hpp"
 #include "rclcpp/logging.hpp"
 #include "rclcpp/time.hpp"
-#include "realtime_tools/thread_priority.hpp"
+#include "realtime_tools/realtime_helpers.hpp"
 
 namespace realtime_tools
 {

--- a/include/realtime_tools/realtime_helpers.hpp
+++ b/include/realtime_tools/realtime_helpers.hpp
@@ -26,13 +26,33 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#ifndef REALTIME_TOOLS__THREAD_PRIORITY_HPP_
-#define REALTIME_TOOLS__THREAD_PRIORITY_HPP_
+#ifndef REALTIME_TOOLS__REALTIME_HELPERS_HPP_
+#define REALTIME_TOOLS__REALTIME_HELPERS_HPP_
 
-#include "realtime_tools/realtime_helpers.hpp"
+#include <string>
 
-// Deprecation notice
-#warning \
-  "This header include is deprecated. Please update your code to use 'realtime_helpers.hpp' header and link against 'realtime_helpers' library." //NOLINT
+namespace realtime_tools
+{
+/**
+ * Detect if realtime kernel is present.
+ * \returns true if realtime kernel is detected
+ */
+bool has_realtime_kernel();
 
-#endif  // REALTIME_TOOLS__THREAD_PRIORITY_HPP_
+/**
+ * Configure SCHED_FIFO thread priority for the thread that calls this function
+ * \param[in] priority the priority of this thread from 0-99
+ * \returns true if configuring scheduler succeeded
+ */
+bool configure_sched_fifo(int priority);
+
+/**
+ * Locks the memory pages of the calling thread to prevent page faults. By calling this method, the programs locks all pages mapped into the address space of the calling process and future mappings. This means that the kernel will not swap out the pages to disk i.e., the pages are guaranteed to stay in RAM until later unlocked - which is important for realtime applications.
+ * \param[out] message a message describing the result of the operation
+ * \returns true if memory locking succeeded, false otherwise
+*/
+bool lock_memory(std::string & message);
+
+}  // namespace realtime_tools
+
+#endif  // REALTIME_TOOLS__REALTIME_HELPERS_HPP_

--- a/include/realtime_tools/thread_priority.hpp
+++ b/include/realtime_tools/thread_priority.hpp
@@ -33,6 +33,6 @@
 
 // Deprecation notice
 #warning \
-  "This header include is deprecated. Please update your code to use 'realtime_helpers.hpp' header and link against 'realtime_helpers' library." //NOLINT
+  "This header include is deprecated. Please update your code to use 'realtime_helpers.hpp' header and link against 'realtime_tools' library." //NOLINT
 
 #endif  // REALTIME_TOOLS__THREAD_PRIORITY_HPP_

--- a/src/realtime_helpers.cpp
+++ b/src/realtime_helpers.cpp
@@ -26,7 +26,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include "realtime_tools/thread_priority.hpp"
+#include "realtime_tools/realtime_helpers.hpp"
 
 #ifdef _WIN32
 #include <windows.h>


### PR DESCRIPTION
Fixes: https://github.com/ros-controls/realtime_tools/issues/177

This is done to also have backward compatibility