### PR TITLE
Fix build error with clang

### DIFF
--- a/include/realtime_tools/realtime_box_best_effort.h
+++ b/include/realtime_tools/realtime_box_best_effort.h
@@ -71,7 +71,7 @@ public:
   template <typename U = T>
   constexpr RealtimeBoxBestEffort(
     const std::initializer_list<U> & init,
-    std::enable_if_t<std::is_constructible_v<U, std::initializer_list>>)
+    std::enable_if_t<std::is_constructible_v<U, std::initializer_list<U>>>)
   : value_(init)
   {
   }


### PR DESCRIPTION
When users try to include the `realtime_box_best_effort.h` header and build their project with clang the following error will come up (tested on Ubuntu 24.04 and Jazzy):

```
--- stderr: realtime_tools                              
In file included from /usr/local/google/home/lucadv/ws_control/src/realtime_tools/test/realtime_box_best_effort_tests.cpp:32:
/usr/local/google/home/lucadv/ws_control/src/realtime_tools/include/realtime_tools/realtime_box_best_effort.h:74:54: error: use of class template 'std::initializer_list' requires template arguments
   74 |     std::enable_if_t<std::is_constructible_v<U, std::initializer_list>>)
      |                                                      ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/initializer_list:45:11: note: template is declared here
   44 |   template<class _E>
      |   ~~~~~~~~~~~~~~~~~~
   45 |     class initializer_list
      |           ^
1 error generated.
```

I just added the template argument to the initializer list and this seems to satisfy clang / not break gcc.

### Test it!

Just build with the clang mixin before and after this PR:

```
colcon build --mixin clang
```