### PR TITLE
Add the same compile flags as with ros2_controllers and fix errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,8 @@ cmake_minimum_required(VERSION 3.16)
 project(realtime_tools LANGUAGES CXX)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
-  add_compile_options(-Wall -Wextra)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror=conversion -Werror=unused-but-set-variable
+  -Werror=return-type -Werror=shadow -Werror=format)
 endif()
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS

--- a/include/realtime_tools/realtime_helpers.hpp
+++ b/include/realtime_tools/realtime_helpers.hpp
@@ -88,7 +88,7 @@ std::pair<bool, std::string> set_current_thread_affinity(int core);
  * \ref https://stackoverflow.com/a/150971
  * \returns The number of processors currently online (available)
 */
-int get_number_of_available_processors();
+int64_t get_number_of_available_processors();
 
 }  // namespace realtime_tools
 

--- a/src/realtime_helpers.cpp
+++ b/src/realtime_helpers.cpp
@@ -122,27 +122,26 @@ std::pair<bool, std::string> set_thread_affinity(int pid, int core)
   message = "Thread affinity is not supported on Windows.";
   return std::make_pair(false, message);
 #else
-  auto set_affinity_result_message = [](int result, std::string & message) -> bool {
+  auto set_affinity_result_message = [](int result, std::string & msg) -> bool {
     if (result == 0) {
-      message = "Thread affinity set successfully!";
+      msg = "Thread affinity set successfully!";
       return true;
     }
     switch (errno) {
       case EFAULT:
-        message = "Call of sched_setaffinity with invalid cpuset!";
+        msg = "Call of sched_setaffinity with invalid cpuset!";
         break;
       case EINVAL:
-        message = "Call of sched_setaffinity with an invalid cpu core!";
+        msg = "Call of sched_setaffinity with an invalid cpu core!";
         break;
       case ESRCH:
-        message =
-          "Call of sched_setaffinity with a thread id/process id that is invalid or not found!";
+        msg = "Call of sched_setaffinity with a thread id/process id that is invalid or not found!";
         break;
       case EPERM:
-        message = "Call of sched_setaffinity with insufficient privileges!";
+        msg = "Call of sched_setaffinity with insufficient privileges!";
         break;
       default:
-        message = "Unknown error code: " + std::string(strerror(errno));
+        msg = "Unknown error code: " + std::string(strerror(errno));
     }
     return false;
   };

--- a/src/realtime_helpers.cpp
+++ b/src/realtime_helpers.cpp
@@ -184,12 +184,12 @@ std::pair<bool, std::string> set_current_thread_affinity(int core)
   return set_thread_affinity(0, core);
 }
 
-int get_number_of_available_processors()
+int64_t get_number_of_available_processors()
 {
 #ifdef _WIN32
   SYSTEM_INFO sysinfo;
   GetSystemInfo(&sysinfo);
-  return sysinfo.dwNumberOfProcessors;
+  return static_cast<int64_t>(sysinfo.dwNumberOfProcessors);
 #else
   return sysconf(_SC_NPROCESSORS_ONLN);
 #endif

--- a/test/realtime_box_best_effort_tests.cpp
+++ b/test/realtime_box_best_effort_tests.cpp
@@ -86,9 +86,7 @@ TEST(RealtimeBoxBestEffort, non_default_constructable)
 }
 TEST(RealtimeBoxBestEffort, standard_get)
 {
-  DefaultConstructable data_construct;
-  data_construct.a = 1000;
-  RealtimeBoxBestEffort<DefaultConstructable> box(data_construct);
+  RealtimeBoxBestEffort<DefaultConstructable> box(DefaultConstructable{1000});
 
   DefaultConstructable data;
   box.get(data);

--- a/test/realtime_box_best_effort_tests.cpp
+++ b/test/realtime_box_best_effort_tests.cpp
@@ -86,7 +86,9 @@ TEST(RealtimeBoxBestEffort, non_default_constructable)
 }
 TEST(RealtimeBoxBestEffort, standard_get)
 {
-  RealtimeBoxBestEffort<DefaultConstructable> box(DefaultConstructable{.a = 1000});
+  DefaultConstructable data_construct;
+  data_construct.a = 1000;
+  RealtimeBoxBestEffort<DefaultConstructable> box(data_construct);
 
   DefaultConstructable data;
   box.get(data);
@@ -122,7 +124,10 @@ TEST(RealtimeBoxBestEffort, assignment_operator)
 }
 TEST(RealtimeBoxBestEffort, typecast_operator)
 {
-  RealtimeBoxBestEffort box(DefaultConstructable{.a = 100, .str = ""});
+  DefaultConstructable data_construct;
+  data_construct.a = 100;
+  data_construct.str = "";
+  RealtimeBoxBestEffort box(data_construct);
 
   // Use non RT access
   DefaultConstructable data = box;
@@ -130,7 +135,7 @@ TEST(RealtimeBoxBestEffort, typecast_operator)
   EXPECT_EQ(data.a, 100);
 
   // Use RT access -> returns std::nullopt if the mutex could not be locked
-  std::optional<DefaultConstructable> rt_data_access = box;
+  std::optional<DefaultConstructable> rt_data_access = box.tryGet();
 
   if (rt_data_access) {
     EXPECT_EQ(rt_data_access->a, 100);

--- a/test/test_async_function_handler.cpp
+++ b/test/test_async_function_handler.cpp
@@ -242,8 +242,8 @@ TEST_F(AsyncFunctionHandlerTest, test_with_deactivate_and_activate_cycles)
   async_class.deactivate();
   async_class.get_handler().wait_for_trigger_cycle_to_finish();
   for (int i = 0; i < 50; i++) {
-    const auto trigger_status = async_class.trigger();
-    ASSERT_FALSE(trigger_status.first);
+    const auto trigger_status_deactivated = async_class.trigger();
+    ASSERT_FALSE(trigger_status_deactivated.first);
     ASSERT_EQ(async_class.get_counter(), total_cycles)
       << "The trigger should fail for any state different than ACTIVE";
   }

--- a/test/thread_priority_tests.cpp
+++ b/test/thread_priority_tests.cpp
@@ -48,7 +48,7 @@ TEST(thread_priority, set_thread_affinity_valid)
 
 TEST(thread_priority, set_thread_affinity_invalid_too_many_cores)
 {
-  const auto count = realtime_tools::get_number_of_available_processors();
+  const int count = static_cast<int>(realtime_tools::get_number_of_available_processors());
   // We should always have at least one core
   EXPECT_FALSE(realtime_tools::set_thread_affinity(0, count + 10).first);
 }


### PR DESCRIPTION
Similar to https://github.com/ros-controls/ros2_controllers/pull/961

@firesurfer as we don't have c++20 on humble, we get an error with the designated initializers. 
And I'm not sure about the line 
```c++
std::optional<DefaultConstructable> rt_data_access = box;
```
which gave the error
```
/workspaces/ros2_rolling_ws/src/realtime_tools/test/realtime_box_best_effort_tests.cpp:133:56: error: choosing ‘constexpr std::optional<_Tp>::optional(_Up&&) [with _Up = realtime_tools::RealtimeBoxBestEffort<DefaultConstructable>&; typename std::enable_if<__and_v<std::__not_<std::is_same<std::optional<_Tp>, typename std::remove_cv<typename std::remove_reference<_Tuple>::type>::type> >, std::__not_<std::is_same<std::in_place_t, typename std::remove_cv<typename std::remove_reference<_Tuple>::type>::type> >, std::is_constructible<_T1, _U1>, std::is_convertible<_U1, _T1> >, bool>::type <anonymous> = true; _Tp = DefaultConstructable]’ over ‘realtime_tools::RealtimeBoxBestEffort<T, mutex_type>::operator std::optional<_Tp>() const [with U = DefaultConstructable; <template-parameter-2-2> = void; T = DefaultConstructable; mutex_type = std::mutex]’ [-Werror=conversion]
  133 |   std::optional<DefaultConstructable> rt_data_access = box;
      |                                                        ^~~
/workspaces/ros2_rolling_ws/src/realtime_tools/test/realtime_box_best_effort_tests.cpp:133:56: error:   for conversion from ‘realtime_tools::RealtimeBoxBestEffort<DefaultConstructable>’ to ‘std::optional<DefaultConstructable>’ [-Werror=conversion]
/workspaces/ros2_rolling_ws/src/realtime_tools/test/realtime_box_best_effort_tests.cpp:133:56: note:   because conversion sequence for the argument is better
cc1plus: some warnings being treated as errors
```
Could be fixed with 
```c++
std::optional<DefaultConstructable> rt_data_access = box.tryGet();
```
or
```c++
std::optional<DefaultConstructable> rt_data_access = static_cast<std::optional<DefaultConstructable>>(box);
```
or maybe with adapting the `std::optional<U>> tryGet() `operator overload?