### PR TITLE
Fix libcap-dev dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -21,7 +21,7 @@
 
   <depend>rclcpp</depend>
   <depend>rclcpp_action</depend>
-  <build_depend>libcap-dev</build_depend>
+  <depend>libcap-dev</depend>
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>lifecycle_msgs</test_depend>


### PR DESCRIPTION
@christophfroehlich reported the missing linking to libcap-dev and later I realised that the dependency is not properly set in the package.xml

https://github.com/ros-controls/control_toolbox/actions/runs/11671849281/job/32499176107

Sorry for the inconvenience 