### PR TITLE
Use windows CI build

### DIFF
--- a/.github/workflows/binary-build-win.yml
+++ b/.github/workflows/binary-build-win.yml
@@ -22,7 +22,7 @@ jobs:
     #   (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/check-windows')) ||
     #   (github.event_name == 'pull_request' && contains(github.event.label.name, 'check-windows')) ||
     #   (github.event_name == 'workflow_dispatch')
-    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-ros-tooling-win-build.yml@windows_ci
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-ros-tooling-win-build.yml@master
     with:
       ros_distro: jazzy
       ref_for_scheduled_build: master

--- a/.github/workflows/binary-build-win.yml
+++ b/.github/workflows/binary-build-win.yml
@@ -1,0 +1,29 @@
+name: Binary Build Windows
+# author: Christoph Fröhlich <christoph.froehlich@ait.ac.at>
+# description: 'Build & test all dependencies from released (binary) windows packages.'
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+    # types:
+    #   - labeled
+  push:
+    branches:
+      - master
+  # issue_comment:
+  #   types:
+  #     - created
+
+jobs:
+  binary-windows:
+    # if: |
+    #   (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/check-windows')) ||
+    #   (github.event_name == 'pull_request' && contains(github.event.label.name, 'check-windows')) ||
+    #   (github.event_name == 'workflow_dispatch')
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-ros-tooling-win-build.yml@windows_ci
+    with:
+      ros_distro: jazzy
+      ref: master
+      os_name: windows-2019

--- a/.github/workflows/binary-build-win.yml
+++ b/.github/workflows/binary-build-win.yml
@@ -25,5 +25,5 @@ jobs:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-ros-tooling-win-build.yml@windows_ci
     with:
       ros_distro: jazzy
-      ref: master
+      ref_for_scheduled_build: master
       os_name: windows-2019

--- a/.github/workflows/binary-build-win.yml
+++ b/.github/workflows/binary-build-win.yml
@@ -1,4 +1,4 @@
-name: Binary Build Windows
+name: Windows Binary Build
 # author: Christoph Fröhlich <christoph.froehlich@ait.ac.at>
 # description: 'Build & test all dependencies from released (binary) windows packages.'
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,16 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
   -Werror=return-type -Werror=shadow -Werror=format)
 endif()
 
+if(WIN32)
+  add_compile_definitions(
+    # For math constants
+    _USE_MATH_DEFINES
+    # Minimize Windows namespace collision
+    NOMINMAX
+    WIN32_LEAN_AND_MEAN
+  )
+endif()
+
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   rclcpp
   rclcpp_action

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ if(WIN32)
     NOMINMAX
     WIN32_LEAN_AND_MEAN
   )
+  # set the same behavior for windows as it is on linux
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 endif()
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS

--- a/test/realtime_box_tests.cpp
+++ b/test/realtime_box_tests.cpp
@@ -28,7 +28,10 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include <gmock/gmock.h>
-#include <realtime_tools/realtime_box.h>
+
+#include <array>
+
+#include "realtime_tools/realtime_box.h"
 
 struct DefaultConstructable
 {

--- a/test/test_async_function_handler.cpp
+++ b/test/test_async_function_handler.cpp
@@ -23,7 +23,7 @@ namespace realtime_tools
 TestAsyncFunctionHandler::TestAsyncFunctionHandler()
 : state_(rclcpp_lifecycle::State(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, "test_async")),
   counter_(0),
-  return_state_(return_type::OK)
+  return_state_(return_type::Ok)
 {
   reset_counter(0);
 }
@@ -36,7 +36,7 @@ void TestAsyncFunctionHandler::initialize()
     [this]() {
       return (
         state_.id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE &&
-        handler_.get_last_return_value() != realtime_tools::return_type::DEACTIVATE);
+        handler_.get_last_return_value() != realtime_tools::return_type::Deactivate);
     });
 }
 
@@ -106,7 +106,7 @@ TEST_F(AsyncFunctionHandlerTest, check_initialization)
   async_class.get_handler().start_thread();
   auto trigger_status = async_class.trigger();
   ASSERT_TRUE(trigger_status.first);
-  ASSERT_EQ(realtime_tools::return_type::OK, trigger_status.second);
+  ASSERT_EQ(realtime_tools::return_type::Ok, trigger_status.second);
   ASSERT_TRUE(async_class.get_handler().is_initialized());
   ASSERT_TRUE(async_class.get_handler().is_running());
   ASSERT_FALSE(async_class.get_handler().is_stopped());
@@ -138,7 +138,7 @@ TEST_F(AsyncFunctionHandlerTest, check_triggering)
   EXPECT_EQ(async_class.get_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
   auto trigger_status = async_class.trigger();
   ASSERT_TRUE(trigger_status.first);
-  ASSERT_EQ(realtime_tools::return_type::OK, trigger_status.second);
+  ASSERT_EQ(realtime_tools::return_type::Ok, trigger_status.second);
   ASSERT_TRUE(async_class.get_handler().is_initialized());
   ASSERT_TRUE(async_class.get_handler().is_running());
   ASSERT_FALSE(async_class.get_handler().is_stopped());
@@ -152,7 +152,7 @@ TEST_F(AsyncFunctionHandlerTest, check_triggering)
   // Trigger one more cycle
   trigger_status = async_class.trigger();
   ASSERT_TRUE(trigger_status.first);
-  ASSERT_EQ(realtime_tools::return_type::OK, trigger_status.second);
+  ASSERT_EQ(realtime_tools::return_type::Ok, trigger_status.second);
   ASSERT_TRUE(async_class.get_handler().is_initialized());
   ASSERT_TRUE(async_class.get_handler().is_running());
   ASSERT_FALSE(async_class.get_handler().is_stopped());
@@ -182,7 +182,7 @@ TEST_F(AsyncFunctionHandlerTest, trigger_for_several_cycles)
   for (int i = 1; i < total_cycles; i++) {
     const auto trigger_status = async_class.trigger();
     if (trigger_status.first) {
-      ASSERT_EQ(realtime_tools::return_type::OK, trigger_status.second);
+      ASSERT_EQ(realtime_tools::return_type::Ok, trigger_status.second);
       ASSERT_TRUE(async_class.get_handler().is_initialized());
       ASSERT_TRUE(async_class.get_handler().is_running());
       ASSERT_FALSE(async_class.get_handler().is_stopped());
@@ -227,7 +227,7 @@ TEST_F(AsyncFunctionHandlerTest, test_with_deactivate_and_activate_cycles)
   for (int i = 1; i < total_cycles; i++) {
     const auto trigger_status = async_class.trigger();
     ASSERT_TRUE(trigger_status.first);
-    ASSERT_EQ(realtime_tools::return_type::OK, trigger_status.second);
+    ASSERT_EQ(realtime_tools::return_type::Ok, trigger_status.second);
     ASSERT_TRUE(async_class.get_handler().is_trigger_cycle_in_progress());
     ASSERT_TRUE(async_class.get_handler().is_initialized());
     ASSERT_TRUE(async_class.get_handler().is_running());
@@ -242,7 +242,7 @@ TEST_F(AsyncFunctionHandlerTest, test_with_deactivate_and_activate_cycles)
   // the thread once the cycle is finished
   auto trigger_status = async_class.trigger();
   ASSERT_TRUE(trigger_status.first);
-  ASSERT_EQ(realtime_tools::return_type::OK, trigger_status.second);
+  ASSERT_EQ(realtime_tools::return_type::Ok, trigger_status.second);
   async_class.deactivate();
   async_class.get_handler().wait_for_trigger_cycle_to_finish();
   for (int i = 0; i < 50; i++) {
@@ -263,7 +263,7 @@ TEST_F(AsyncFunctionHandlerTest, test_with_deactivate_and_activate_cycles)
   EXPECT_EQ(async_class.get_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
   trigger_status = async_class.trigger();
   ASSERT_TRUE(trigger_status.first);
-  ASSERT_EQ(realtime_tools::return_type::OK, trigger_status.second);
+  ASSERT_EQ(realtime_tools::return_type::Ok, trigger_status.second);
   async_class.get_handler().wait_for_trigger_cycle_to_finish();
   async_class.deactivate();
   EXPECT_EQ(async_class.get_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
@@ -291,7 +291,7 @@ TEST_F(AsyncFunctionHandlerTest, check_triggering_with_different_return_state_an
   EXPECT_EQ(async_class.get_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
   auto trigger_status = async_class.trigger();
   ASSERT_TRUE(trigger_status.first);
-  ASSERT_EQ(realtime_tools::return_type::OK, trigger_status.second);
+  ASSERT_EQ(realtime_tools::return_type::Ok, trigger_status.second);
   ASSERT_TRUE(async_class.get_handler().is_initialized());
   ASSERT_TRUE(async_class.get_handler().is_running());
   ASSERT_FALSE(async_class.get_handler().is_stopped());
@@ -299,47 +299,47 @@ TEST_F(AsyncFunctionHandlerTest, check_triggering_with_different_return_state_an
   ASSERT_TRUE(async_class.get_handler().is_trigger_cycle_in_progress());
   async_class.get_handler().wait_for_trigger_cycle_to_finish();
   async_class.get_handler().get_last_execution_time();
-  ASSERT_EQ(async_class.get_handler().get_last_return_value(), realtime_tools::return_type::OK);
+  ASSERT_EQ(async_class.get_handler().get_last_return_value(), realtime_tools::return_type::Ok);
   ASSERT_FALSE(async_class.get_handler().is_trigger_cycle_in_progress());
   ASSERT_EQ(async_class.get_counter(), 1);
 
   // Trigger one more cycle to return ERROR at the end of cycle,
   // so return from this cycle should be last cycle's return
-  async_class.set_return_state(realtime_tools::return_type::ERROR);
+  async_class.set_return_state(realtime_tools::return_type::Error);
   trigger_status = async_class.trigger();
   ASSERT_TRUE(trigger_status.first);
-  ASSERT_EQ(realtime_tools::return_type::OK, trigger_status.second);
+  ASSERT_EQ(realtime_tools::return_type::Ok, trigger_status.second);
   ASSERT_TRUE(async_class.get_handler().is_initialized());
   ASSERT_TRUE(async_class.get_handler().is_running());
   ASSERT_FALSE(async_class.get_handler().is_stopped());
   ASSERT_TRUE(async_class.get_handler().is_trigger_cycle_in_progress());
-  ASSERT_EQ(async_class.get_handler().get_last_return_value(), realtime_tools::return_type::OK);
+  ASSERT_EQ(async_class.get_handler().get_last_return_value(), realtime_tools::return_type::Ok);
   async_class.get_handler().wait_for_trigger_cycle_to_finish();
   ASSERT_FALSE(async_class.get_handler().is_trigger_cycle_in_progress());
-  ASSERT_EQ(async_class.get_handler().get_last_return_value(), realtime_tools::return_type::ERROR);
+  ASSERT_EQ(async_class.get_handler().get_last_return_value(), realtime_tools::return_type::Error);
   ASSERT_LE(async_class.get_counter(), 2);
 
   // Trigger one more cycle to return DEACTIVATE at the end of cycle,
-  async_class.set_return_state(realtime_tools::return_type::DEACTIVATE);
+  async_class.set_return_state(realtime_tools::return_type::Deactivate);
   trigger_status = async_class.trigger();
   ASSERT_TRUE(trigger_status.first);
-  ASSERT_EQ(realtime_tools::return_type::ERROR, trigger_status.second);
+  ASSERT_EQ(realtime_tools::return_type::Error, trigger_status.second);
   ASSERT_TRUE(async_class.get_handler().is_initialized());
   ASSERT_TRUE(async_class.get_handler().is_running());
   ASSERT_FALSE(async_class.get_handler().is_stopped());
   ASSERT_FALSE(async_class.get_handler().is_stopped());
   ASSERT_TRUE(async_class.get_handler().is_trigger_cycle_in_progress());
-  ASSERT_EQ(async_class.get_handler().get_last_return_value(), realtime_tools::return_type::ERROR);
+  ASSERT_EQ(async_class.get_handler().get_last_return_value(), realtime_tools::return_type::Error);
   async_class.get_handler().wait_for_trigger_cycle_to_finish();
   ASSERT_FALSE(async_class.get_handler().is_trigger_cycle_in_progress());
   ASSERT_EQ(
-    async_class.get_handler().get_last_return_value(), realtime_tools::return_type::DEACTIVATE);
+    async_class.get_handler().get_last_return_value(), realtime_tools::return_type::Deactivate);
   ASSERT_LE(async_class.get_counter(), 3);
 
   // Now the next trigger shouldn't happen as the predicate is set to DEACTIVATE
   trigger_status = async_class.trigger();
   ASSERT_FALSE(trigger_status.first) << "The trigger should fail as the predicate is DEACTIVATE";
-  ASSERT_EQ(realtime_tools::return_type::DEACTIVATE, trigger_status.second);
+  ASSERT_EQ(realtime_tools::return_type::Deactivate, trigger_status.second);
   ASSERT_FALSE(async_class.get_handler().is_trigger_cycle_in_progress());
 
   async_class.get_handler().stop_thread();
@@ -358,7 +358,7 @@ TEST_F(AsyncFunctionHandlerTest, check_exception_handling)
   EXPECT_EQ(async_class.get_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
   auto trigger_status = async_class.trigger();
   ASSERT_TRUE(trigger_status.first);
-  ASSERT_EQ(realtime_tools::return_type::OK, trigger_status.second);
+  ASSERT_EQ(realtime_tools::return_type::Ok, trigger_status.second);
   ASSERT_TRUE(async_class.get_handler().is_initialized());
   ASSERT_TRUE(async_class.get_handler().is_running());
   ASSERT_FALSE(async_class.get_handler().is_stopped());
@@ -373,7 +373,7 @@ TEST_F(AsyncFunctionHandlerTest, check_exception_handling)
   async_class.reset_counter(std::numeric_limits<int>::max());
   trigger_status = async_class.trigger();
   ASSERT_TRUE(trigger_status.first);
-  ASSERT_EQ(realtime_tools::return_type::OK, trigger_status.second);
+  ASSERT_EQ(realtime_tools::return_type::Ok, trigger_status.second);
   ASSERT_TRUE(async_class.get_handler().is_initialized());
   ASSERT_TRUE(async_class.get_handler().is_running());
   ASSERT_FALSE(async_class.get_handler().is_stopped());
@@ -401,7 +401,7 @@ TEST_F(AsyncFunctionHandlerTest, check_exception_handling)
   async_class.get_handler().start_thread();
   trigger_status = async_class.trigger();
   ASSERT_TRUE(trigger_status.first);
-  ASSERT_EQ(realtime_tools::return_type::OK, trigger_status.second);
+  ASSERT_EQ(realtime_tools::return_type::Ok, trigger_status.second);
   ASSERT_TRUE(async_class.get_handler().is_initialized());
   ASSERT_TRUE(async_class.get_handler().is_running());
   ASSERT_FALSE(async_class.get_handler().is_stopped());

--- a/test/test_async_function_handler.cpp
+++ b/test/test_async_function_handler.cpp
@@ -23,7 +23,7 @@ namespace realtime_tools
 TestAsyncFunctionHandler::TestAsyncFunctionHandler()
 : state_(rclcpp_lifecycle::State(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, "test_async")),
   counter_(0),
-  return_state_(return_type::Ok)
+  return_state_(return_type::OK)
 {
   reset_counter(0);
 }
@@ -36,7 +36,7 @@ void TestAsyncFunctionHandler::initialize()
     [this]() {
       return (
         state_.id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE &&
-        handler_.get_last_return_value() != realtime_tools::return_type::Deactivate);
+        handler_.get_last_return_value() != realtime_tools::return_type::DEACTIVATE);
     });
 }
 
@@ -106,7 +106,7 @@ TEST_F(AsyncFunctionHandlerTest, check_initialization)
   async_class.get_handler().start_thread();
   auto trigger_status = async_class.trigger();
   ASSERT_TRUE(trigger_status.first);
-  ASSERT_EQ(realtime_tools::return_type::Ok, trigger_status.second);
+  ASSERT_EQ(realtime_tools::return_type::OK, trigger_status.second);
   ASSERT_TRUE(async_class.get_handler().is_initialized());
   ASSERT_TRUE(async_class.get_handler().is_running());
   ASSERT_FALSE(async_class.get_handler().is_stopped());
@@ -138,7 +138,7 @@ TEST_F(AsyncFunctionHandlerTest, check_triggering)
   EXPECT_EQ(async_class.get_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
   auto trigger_status = async_class.trigger();
   ASSERT_TRUE(trigger_status.first);
-  ASSERT_EQ(realtime_tools::return_type::Ok, trigger_status.second);
+  ASSERT_EQ(realtime_tools::return_type::OK, trigger_status.second);
   ASSERT_TRUE(async_class.get_handler().is_initialized());
   ASSERT_TRUE(async_class.get_handler().is_running());
   ASSERT_FALSE(async_class.get_handler().is_stopped());
@@ -152,7 +152,7 @@ TEST_F(AsyncFunctionHandlerTest, check_triggering)
   // Trigger one more cycle
   trigger_status = async_class.trigger();
   ASSERT_TRUE(trigger_status.first);
-  ASSERT_EQ(realtime_tools::return_type::Ok, trigger_status.second);
+  ASSERT_EQ(realtime_tools::return_type::OK, trigger_status.second);
   ASSERT_TRUE(async_class.get_handler().is_initialized());
   ASSERT_TRUE(async_class.get_handler().is_running());
   ASSERT_FALSE(async_class.get_handler().is_stopped());
@@ -182,7 +182,7 @@ TEST_F(AsyncFunctionHandlerTest, trigger_for_several_cycles)
   for (int i = 1; i < total_cycles; i++) {
     const auto trigger_status = async_class.trigger();
     if (trigger_status.first) {
-      ASSERT_EQ(realtime_tools::return_type::Ok, trigger_status.second);
+      ASSERT_EQ(realtime_tools::return_type::OK, trigger_status.second);
       ASSERT_TRUE(async_class.get_handler().is_initialized());
       ASSERT_TRUE(async_class.get_handler().is_running());
       ASSERT_FALSE(async_class.get_handler().is_stopped());
@@ -227,7 +227,7 @@ TEST_F(AsyncFunctionHandlerTest, test_with_deactivate_and_activate_cycles)
   for (int i = 1; i < total_cycles; i++) {
     const auto trigger_status = async_class.trigger();
     ASSERT_TRUE(trigger_status.first);
-    ASSERT_EQ(realtime_tools::return_type::Ok, trigger_status.second);
+    ASSERT_EQ(realtime_tools::return_type::OK, trigger_status.second);
     ASSERT_TRUE(async_class.get_handler().is_trigger_cycle_in_progress());
     ASSERT_TRUE(async_class.get_handler().is_initialized());
     ASSERT_TRUE(async_class.get_handler().is_running());
@@ -242,7 +242,7 @@ TEST_F(AsyncFunctionHandlerTest, test_with_deactivate_and_activate_cycles)
   // the thread once the cycle is finished
   auto trigger_status = async_class.trigger();
   ASSERT_TRUE(trigger_status.first);
-  ASSERT_EQ(realtime_tools::return_type::Ok, trigger_status.second);
+  ASSERT_EQ(realtime_tools::return_type::OK, trigger_status.second);
   async_class.deactivate();
   async_class.get_handler().wait_for_trigger_cycle_to_finish();
   for (int i = 0; i < 50; i++) {
@@ -263,7 +263,7 @@ TEST_F(AsyncFunctionHandlerTest, test_with_deactivate_and_activate_cycles)
   EXPECT_EQ(async_class.get_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
   trigger_status = async_class.trigger();
   ASSERT_TRUE(trigger_status.first);
-  ASSERT_EQ(realtime_tools::return_type::Ok, trigger_status.second);
+  ASSERT_EQ(realtime_tools::return_type::OK, trigger_status.second);
   async_class.get_handler().wait_for_trigger_cycle_to_finish();
   async_class.deactivate();
   EXPECT_EQ(async_class.get_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
@@ -291,7 +291,7 @@ TEST_F(AsyncFunctionHandlerTest, check_triggering_with_different_return_state_an
   EXPECT_EQ(async_class.get_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
   auto trigger_status = async_class.trigger();
   ASSERT_TRUE(trigger_status.first);
-  ASSERT_EQ(realtime_tools::return_type::Ok, trigger_status.second);
+  ASSERT_EQ(realtime_tools::return_type::OK, trigger_status.second);
   ASSERT_TRUE(async_class.get_handler().is_initialized());
   ASSERT_TRUE(async_class.get_handler().is_running());
   ASSERT_FALSE(async_class.get_handler().is_stopped());
@@ -299,47 +299,47 @@ TEST_F(AsyncFunctionHandlerTest, check_triggering_with_different_return_state_an
   ASSERT_TRUE(async_class.get_handler().is_trigger_cycle_in_progress());
   async_class.get_handler().wait_for_trigger_cycle_to_finish();
   async_class.get_handler().get_last_execution_time();
-  ASSERT_EQ(async_class.get_handler().get_last_return_value(), realtime_tools::return_type::Ok);
+  ASSERT_EQ(async_class.get_handler().get_last_return_value(), realtime_tools::return_type::OK);
   ASSERT_FALSE(async_class.get_handler().is_trigger_cycle_in_progress());
   ASSERT_EQ(async_class.get_counter(), 1);
 
   // Trigger one more cycle to return ERROR at the end of cycle,
   // so return from this cycle should be last cycle's return
-  async_class.set_return_state(realtime_tools::return_type::Error);
+  async_class.set_return_state(realtime_tools::return_type::ERROR);
   trigger_status = async_class.trigger();
   ASSERT_TRUE(trigger_status.first);
-  ASSERT_EQ(realtime_tools::return_type::Ok, trigger_status.second);
+  ASSERT_EQ(realtime_tools::return_type::OK, trigger_status.second);
   ASSERT_TRUE(async_class.get_handler().is_initialized());
   ASSERT_TRUE(async_class.get_handler().is_running());
   ASSERT_FALSE(async_class.get_handler().is_stopped());
   ASSERT_TRUE(async_class.get_handler().is_trigger_cycle_in_progress());
-  ASSERT_EQ(async_class.get_handler().get_last_return_value(), realtime_tools::return_type::Ok);
+  ASSERT_EQ(async_class.get_handler().get_last_return_value(), realtime_tools::return_type::OK);
   async_class.get_handler().wait_for_trigger_cycle_to_finish();
   ASSERT_FALSE(async_class.get_handler().is_trigger_cycle_in_progress());
-  ASSERT_EQ(async_class.get_handler().get_last_return_value(), realtime_tools::return_type::Error);
+  ASSERT_EQ(async_class.get_handler().get_last_return_value(), realtime_tools::return_type::ERROR);
   ASSERT_LE(async_class.get_counter(), 2);
 
   // Trigger one more cycle to return DEACTIVATE at the end of cycle,
-  async_class.set_return_state(realtime_tools::return_type::Deactivate);
+  async_class.set_return_state(realtime_tools::return_type::DEACTIVATE);
   trigger_status = async_class.trigger();
   ASSERT_TRUE(trigger_status.first);
-  ASSERT_EQ(realtime_tools::return_type::Error, trigger_status.second);
+  ASSERT_EQ(realtime_tools::return_type::ERROR, trigger_status.second);
   ASSERT_TRUE(async_class.get_handler().is_initialized());
   ASSERT_TRUE(async_class.get_handler().is_running());
   ASSERT_FALSE(async_class.get_handler().is_stopped());
   ASSERT_FALSE(async_class.get_handler().is_stopped());
   ASSERT_TRUE(async_class.get_handler().is_trigger_cycle_in_progress());
-  ASSERT_EQ(async_class.get_handler().get_last_return_value(), realtime_tools::return_type::Error);
+  ASSERT_EQ(async_class.get_handler().get_last_return_value(), realtime_tools::return_type::ERROR);
   async_class.get_handler().wait_for_trigger_cycle_to_finish();
   ASSERT_FALSE(async_class.get_handler().is_trigger_cycle_in_progress());
   ASSERT_EQ(
-    async_class.get_handler().get_last_return_value(), realtime_tools::return_type::Deactivate);
+    async_class.get_handler().get_last_return_value(), realtime_tools::return_type::DEACTIVATE);
   ASSERT_LE(async_class.get_counter(), 3);
 
   // Now the next trigger shouldn't happen as the predicate is set to DEACTIVATE
   trigger_status = async_class.trigger();
   ASSERT_FALSE(trigger_status.first) << "The trigger should fail as the predicate is DEACTIVATE";
-  ASSERT_EQ(realtime_tools::return_type::Deactivate, trigger_status.second);
+  ASSERT_EQ(realtime_tools::return_type::DEACTIVATE, trigger_status.second);
   ASSERT_FALSE(async_class.get_handler().is_trigger_cycle_in_progress());
 
   async_class.get_handler().stop_thread();
@@ -358,7 +358,7 @@ TEST_F(AsyncFunctionHandlerTest, check_exception_handling)
   EXPECT_EQ(async_class.get_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
   auto trigger_status = async_class.trigger();
   ASSERT_TRUE(trigger_status.first);
-  ASSERT_EQ(realtime_tools::return_type::Ok, trigger_status.second);
+  ASSERT_EQ(realtime_tools::return_type::OK, trigger_status.second);
   ASSERT_TRUE(async_class.get_handler().is_initialized());
   ASSERT_TRUE(async_class.get_handler().is_running());
   ASSERT_FALSE(async_class.get_handler().is_stopped());
@@ -373,7 +373,7 @@ TEST_F(AsyncFunctionHandlerTest, check_exception_handling)
   async_class.reset_counter(std::numeric_limits<int>::max());
   trigger_status = async_class.trigger();
   ASSERT_TRUE(trigger_status.first);
-  ASSERT_EQ(realtime_tools::return_type::Ok, trigger_status.second);
+  ASSERT_EQ(realtime_tools::return_type::OK, trigger_status.second);
   ASSERT_TRUE(async_class.get_handler().is_initialized());
   ASSERT_TRUE(async_class.get_handler().is_running());
   ASSERT_FALSE(async_class.get_handler().is_stopped());
@@ -401,7 +401,7 @@ TEST_F(AsyncFunctionHandlerTest, check_exception_handling)
   async_class.get_handler().start_thread();
   trigger_status = async_class.trigger();
   ASSERT_TRUE(trigger_status.first);
-  ASSERT_EQ(realtime_tools::return_type::Ok, trigger_status.second);
+  ASSERT_EQ(realtime_tools::return_type::OK, trigger_status.second);
   ASSERT_TRUE(async_class.get_handler().is_initialized());
   ASSERT_TRUE(async_class.get_handler().is_running());
   ASSERT_FALSE(async_class.get_handler().is_stopped());

--- a/test/test_async_function_handler.cpp
+++ b/test/test_async_function_handler.cpp
@@ -303,9 +303,9 @@ TEST_F(AsyncFunctionHandlerTest, check_triggering_with_different_return_state_an
   ASSERT_FALSE(async_class.get_handler().is_trigger_cycle_in_progress());
   ASSERT_EQ(async_class.get_counter(), 1);
 
-  // Trigger one more cycle to return ERROR at the end of cycle,
+  // Trigger one more cycle to return FAILURE at the end of cycle,
   // so return from this cycle should be last cycle's return
-  async_class.set_return_state(realtime_tools::return_type::ERROR);
+  async_class.set_return_state(realtime_tools::return_type::FAILURE);
   trigger_status = async_class.trigger();
   ASSERT_TRUE(trigger_status.first);
   ASSERT_EQ(realtime_tools::return_type::OK, trigger_status.second);
@@ -316,20 +316,22 @@ TEST_F(AsyncFunctionHandlerTest, check_triggering_with_different_return_state_an
   ASSERT_EQ(async_class.get_handler().get_last_return_value(), realtime_tools::return_type::OK);
   async_class.get_handler().wait_for_trigger_cycle_to_finish();
   ASSERT_FALSE(async_class.get_handler().is_trigger_cycle_in_progress());
-  ASSERT_EQ(async_class.get_handler().get_last_return_value(), realtime_tools::return_type::ERROR);
+  ASSERT_EQ(
+    async_class.get_handler().get_last_return_value(), realtime_tools::return_type::FAILURE);
   ASSERT_LE(async_class.get_counter(), 2);
 
   // Trigger one more cycle to return DEACTIVATE at the end of cycle,
   async_class.set_return_state(realtime_tools::return_type::DEACTIVATE);
   trigger_status = async_class.trigger();
   ASSERT_TRUE(trigger_status.first);
-  ASSERT_EQ(realtime_tools::return_type::ERROR, trigger_status.second);
+  ASSERT_EQ(realtime_tools::return_type::FAILURE, trigger_status.second);
   ASSERT_TRUE(async_class.get_handler().is_initialized());
   ASSERT_TRUE(async_class.get_handler().is_running());
   ASSERT_FALSE(async_class.get_handler().is_stopped());
   ASSERT_FALSE(async_class.get_handler().is_stopped());
   ASSERT_TRUE(async_class.get_handler().is_trigger_cycle_in_progress());
-  ASSERT_EQ(async_class.get_handler().get_last_return_value(), realtime_tools::return_type::ERROR);
+  ASSERT_EQ(
+    async_class.get_handler().get_last_return_value(), realtime_tools::return_type::FAILURE);
   async_class.get_handler().wait_for_trigger_cycle_to_finish();
   ASSERT_FALSE(async_class.get_handler().is_trigger_cycle_in_progress());
   ASSERT_EQ(

--- a/test/test_async_function_handler.hpp
+++ b/test/test_async_function_handler.hpp
@@ -25,7 +25,7 @@ namespace realtime_tools
 {
 enum class return_type : std::uint8_t {
   OK = 0,
-  ERROR = 1,
+  FAILURE = 1,
   DEACTIVATE = 2,
 };
 

--- a/test/test_async_function_handler.hpp
+++ b/test/test_async_function_handler.hpp
@@ -24,9 +24,9 @@
 namespace realtime_tools
 {
 enum class return_type : std::uint8_t {
-  OK = 0,
-  ERROR = 1,
-  DEACTIVATE = 2,
+  Ok = 0,
+  Error = 1,
+  Deactivate = 2,
 };
 
 class TestAsyncFunctionHandler

--- a/test/test_async_function_handler.hpp
+++ b/test/test_async_function_handler.hpp
@@ -24,9 +24,9 @@
 namespace realtime_tools
 {
 enum class return_type : std::uint8_t {
-  Ok = 0,
-  Error = 1,
-  Deactivate = 2,
+  OK = 0,
+  ERROR = 1,
+  DEACTIVATE = 2,
 };
 
 class TestAsyncFunctionHandler


### PR DESCRIPTION
The main purpose is to avoid adding code which does not compile on Windows. Github provides windows-2019 runners, which can be used here. However, https://github.com/nektos/gh-act does not support this and I was only to test the workflow online.

- Binary releases are not published for rolling, so I hardcoded jazzy
- I added it now to be triggered at PRs and pushes, but it might be configured to run on comments/labels only.
- Needs https://github.com/ros-controls/ros2_control_ci/pull/175
