### PR TITLE
Adapt API style of lock_memory to match the one of the other functions

### DIFF
--- a/include/realtime_tools/realtime_helpers.hpp
+++ b/include/realtime_tools/realtime_helpers.hpp
@@ -62,9 +62,10 @@ bool configure_sched_fifo(int priority);
  * will not swap out the pages to disk i.e., the pages are guaranteed to stay in
  * RAM until later unlocked - which is important for realtime applications.
  * \param[out] message a message describing the result of the operation
- * \returns true if memory locking succeeded, false otherwise
+ * \returns  a pair of a boolean indicating whether the operation succeeded or not
+ * and a message describing the result of the operation
 */
-bool lock_memory(std::string & message);
+std::pair<bool, std::string> lock_memory();
 
 /**
  * Configure the caller thread affinity - Tell the scheduler to prefer a certain

--- a/src/realtime_helpers.cpp
+++ b/src/realtime_helpers.cpp
@@ -64,11 +64,10 @@ bool configure_sched_fifo(int priority)
 #endif
 }
 
-bool lock_memory(std::string & message)
+std::pair<bool, std::string> lock_memory()
 {
 #ifdef _WIN32
-  message = "Memory locking is not supported on Windows.";
-  return false;
+  return {false, "Memory locking is not supported on Windows."};
 #else
   auto is_capable = [](cap_value_t v) -> bool {
     bool rc = false;
@@ -86,6 +85,7 @@ bool lock_memory(std::string & message)
     return rc;
   };
 
+  std::string message;
   if (mlockall(MCL_CURRENT | MCL_FUTURE) == -1) {
     if (!is_capable(CAP_IPC_LOCK)) {
       message = "No proper privileges to lock the memory!";
@@ -105,10 +105,10 @@ bool lock_memory(std::string & message)
     } else {
       message = "Unknown error occurred!";
     }
-    return false;
+    return {false, message};
   } else {
     message = "Memory locked successfully!";
-    return true;
+    return {true, message};
   }
 #endif
 }


### PR DESCRIPTION
This PR adapts the API style of the lock_memory function to match the style of the other methods.

I will create a PR that adapts the usage in ros2 control:
https://github.com/search?q=repo%3Aros-controls%2Fros2_control%20lock_memory&type=code

Which is also the only place it is currently used:
https://github.com/search?q=realtime_tools%3A%3Alock_memory&type=code