### PR TITLE
Deprecate RealtimeClock class

### DIFF
--- a/include/realtime_tools/realtime_clock.hpp
+++ b/include/realtime_tools/realtime_clock.hpp
@@ -43,7 +43,7 @@
 
 namespace realtime_tools
 {
-class RealtimeClock
+class [[deprecated("Use rclcpp::Clock or std::chrono::steady_clock instead")]] RealtimeClock
 {
 public:
   /**

--- a/test/realtime_clock_tests.cpp
+++ b/test/realtime_clock_tests.cpp
@@ -34,6 +34,10 @@
 #include "rclcpp/utilities.hpp"
 #include "realtime_tools/realtime_clock.hpp"
 
+// Disable deprecated warnings
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 using realtime_tools::RealtimeClock;
 
 TEST(RealtimeClock, get_system_time)
@@ -59,3 +63,5 @@ TEST(RealtimeClock, get_system_time)
   }
   rclcpp::shutdown();
 }
+
+#pragma GCC diagnostic pop


### PR DESCRIPTION
See #241: Deprecate it for one release, and then remove the class if no one is raising any concern.