### PR TITLE
Avoid to include windows.h in realtime_helpers.hpp

### DIFF
--- a/include/realtime_tools/realtime_helpers.hpp
+++ b/include/realtime_tools/realtime_helpers.hpp
@@ -39,7 +39,7 @@
 // and using HANDLE macro to avoid polluting all the downstream
 // compilation units that include the public header realtime_helpers.hpp
 // with problematic macros like MIN, MAX or ERROR
-using NATIVE_THREAD_HANDLE = void*;
+using NATIVE_THREAD_HANDLE = void *;
 #else
 using NATIVE_THREAD_HANDLE = pthread_t;
 #endif

--- a/include/realtime_tools/realtime_helpers.hpp
+++ b/include/realtime_tools/realtime_helpers.hpp
@@ -35,8 +35,11 @@
 #include <vector>
 
 #ifdef _WIN32
-#include <windows.h>
-using NATIVE_THREAD_HANDLE = HANDLE;
+// Here we directly use void* instead of including windows.h
+// and using HANDLE macro to avoid polluting all the downstream
+// compilation units that include the public header realtime_helpers.hpp
+// with problematic macros like MIN, MAX or ERROR
+using NATIVE_THREAD_HANDLE = void*;
 #else
 using NATIVE_THREAD_HANDLE = pthread_t;
 #endif

--- a/src/realtime_helpers.cpp
+++ b/src/realtime_helpers.cpp
@@ -28,7 +28,9 @@
 
 #include "realtime_tools/realtime_helpers.hpp"
 
-#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#ifdef _WIN32
+#include <windows.h>
+#else
 #include <sched.h>
 #include <sys/capability.h>
 #include <sys/mman.h>


### PR DESCRIPTION
https://github.com/ros-controls/realtime_tools/pull/193 added the inclusion of windows.h in the public header `realtime_helpers.hpp`.

In my limited experience, it is quite important to try to only include windows.h in .cc/.cpp files, as `windows.h` define many problematic macros (`MIN`, `MAX`, `ERROR`) that induce compilation errors when the `realtime_helpers.hpp` header is included before rclcpp or ros_control (as several enums are called `ERROR` in ros_control, see for an example of the confusing errors induced by windows.h https://github.com/ros-controls/gazebo_ros2_control/issues/377 or https://github.com/ros-controls/realtime_tools/pull/204#issuecomment-2498807921, just to mention the most recent I found).

For this reason, I think that in this specific case, even if it may seems not ideal, it is a good idea **not** to include windows.h, and just use directly the value of the `HANDLE` macro, that is `void*` (see https://codemachine.com/downloads/win80/winnt.h or https://github.com/Alexpux/mingw-w64/blob/d0d7f784833bbb0b2d279310ddc6afb52fe47a46/mingw-w64-tools/widl/include/winnt.h#L557 for a reference, or if you are on a Windows machine just open your `winnt.h` file). In general it is not a good idea to assume that a given macro will always have a value, but in this specific case, considering that Win32 API almost never breaks backward compatibility (and that is the reason `MIN`, `MAX` and `ERROR` macros are still around), I think the lesser evil is definitely to using `void*` in place of `HANDLE`.



