### PR TITLE
Improve has_realtime_kernel method

### DIFF
--- a/src/realtime_helpers.cpp
+++ b/src/realtime_helpers.cpp
@@ -47,12 +47,15 @@ namespace realtime_tools
 {
 bool has_realtime_kernel()
 {
+#ifdef _WIN32
+  std::cerr << "Realtime kernel detection is not supported on Windows." << std::endl;
+  return false;
+#else
   std::ifstream realtime_file("/sys/kernel/realtime", std::ios::in);
   bool has_realtime = false;
   if (realtime_file.is_open()) {
     realtime_file >> has_realtime;
   }
-#if !defined(_WIN32)
   if (!has_realtime) {
     struct utsname kernel_info;
     if (uname(&kernel_info) == -1) {
@@ -63,8 +66,8 @@ bool has_realtime_kernel()
     const std::string kernel_version(kernel_info.version);
     return kernel_version.find("PREEMPT_RT") != std::string::npos;
   }
-#endif
   return has_realtime;
+#endif
 }
 
 bool configure_sched_fifo(int priority)

--- a/src/realtime_helpers.cpp
+++ b/src/realtime_helpers.cpp
@@ -42,7 +42,6 @@
 #include <cstring>
 #include <fstream>
 #include <iostream>
-#include <regex>
 
 namespace realtime_tools
 {
@@ -61,9 +60,8 @@ bool has_realtime_kernel()
                 << std::endl;
       return false;
     }
-    const std::string kernel_version(kernel_info.release);
-    const std::regex pattern("(RT|Preempt)", std::regex_constants::icase);
-    return std::regex_search(kernel_version, pattern);
+    const std::string kernel_version(kernel_info.version);
+    return kernel_version.find("PREEMPT_RT") != std::string::npos;
   }
 #endif
   return has_realtime;


### PR DESCRIPTION
These changes allow the detection of realtime kernel even from the `uname` output. It should be more robust.

Fixes: https://github.com/ros-controls/realtime_tools/issues/257