### PR TITLE
Fix startup race condition in realtime publisher

### DIFF
--- a/realtime_tools/include/realtime_tools/realtime_publisher.hpp
+++ b/realtime_tools/include/realtime_tools/realtime_publisher.hpp
@@ -185,12 +185,12 @@ public:
 
   const std::thread & get_thread() const { return thread_; }
 
+  bool is_running() const { return is_running_; }
+
 private:
   // non-copyable
   RealtimePublisher(const RealtimePublisher &) = delete;
   RealtimePublisher & operator=(const RealtimePublisher &) = delete;
-
-  bool is_running() const { return is_running_; }
 
   /**
    * \brief Publishing loop (runs in separate thread)

--- a/realtime_tools/include/realtime_tools/realtime_publisher.hpp
+++ b/realtime_tools/include/realtime_tools/realtime_publisher.hpp
@@ -205,8 +205,8 @@ private:
    */
   void publishingLoop()
   {
-    is_running_ = true;
     turn_.store(State::NON_REALTIME, std::memory_order_release);
+    is_running_ = true;
 
     while (keep_running_) {
       MessageT outgoing;


### PR DESCRIPTION
I discovered a race condition when publishing a reliable message using a realtime publisher at startup. A typical pattern for a reliable topic is to create a publisher and then immediately publish the initial value like the following:

```
s_publisher_ = get_node()->create_publisher<TestMsg>("~/topic", transient_local_qos);
publisher_ = std::make_unique<RealtimePublisher<TestMsg>>(s_publisher_);

publisher_->lock();
// initialize message to publish
publisher_->unlockAndPublish();
```

unlockAndPublish() sets the state to realtime to notify the publishing loop before unlocking so it gets published in the publishing loop. The publisher loop thread first sets the state to nonrealtime and waits for the notification. The race condition is that the setting of state in unlockAndPublish() happens before the publishing loop initializes state so the notification is lost. In this case, the message doesn't get published. In my application, this is random and happens about half the time.

This PR fixes this race condition by inverting the order of initialization in the publisher loop. I also changed the access of is_running() to public. Then the following sequence always works:

```
s_publisher_ = get_node()->create_publisher<TestMsg>("~/topic", transient_local_qos);
publisher_ = std::make_unique<RealtimePublisher<TestMsg>>(s_publisher_);

while (!publisher_->is_running()) {
    std::this_thread::sleep_for(std::chrono::milliseconds(10));
}

publisher_->lock();
// initialize message to publish
publisher_->unlockAndPublish();
```