### PR TITLE
Fix the deadlock in the destructor of RealtimePublisher

### DIFF
--- a/realtime_tools/include/realtime_tools/realtime_publisher.hpp
+++ b/realtime_tools/include/realtime_tools/realtime_publisher.hpp
@@ -99,13 +99,12 @@ public:
   /// Destructor
   ~RealtimePublisher()
   {
-    RCLCPP_DEBUG_STREAM(
-      rclcpp::get_logger("realtime_tools"), "Waiting for publishing thread to stop....");
+    RCLCPP_DEBUG(rclcpp::get_logger("realtime_tools"), "Waiting for publishing thread to stop....");
     stop();
     while (is_running()) {
       std::this_thread::sleep_for(std::chrono::microseconds(100));
     }
-    RCLCPP_DEBUG_STREAM(
+    RCLCPP_DEBUG(
       rclcpp::get_logger("realtime_tools"), "Publishing thread stopped, joining thread....");
     if (thread_.joinable()) {
       thread_.join();

--- a/realtime_tools/include/realtime_tools/realtime_publisher.hpp
+++ b/realtime_tools/include/realtime_tools/realtime_publisher.hpp
@@ -99,10 +99,14 @@ public:
   /// Destructor
   ~RealtimePublisher()
   {
+    RCLCPP_DEBUG_STREAM(
+      rclcpp::get_logger("realtime_tools"), "Waiting for publishing thread to stop....");
     stop();
     while (is_running()) {
       std::this_thread::sleep_for(std::chrono::microseconds(100));
     }
+    RCLCPP_DEBUG_STREAM(
+      rclcpp::get_logger("realtime_tools"), "Publishing thread stopped, joining thread....");
     if (thread_.joinable()) {
       thread_.join();
     }
@@ -117,7 +121,10 @@ public:
    */
   void stop()
   {
-    keep_running_ = false;
+    {
+      std::unique_lock<std::mutex> lock(msg_mutex_);
+      keep_running_ = false;
+    }
     updated_cond_.notify_one();  // So the publishing loop can exit
   }
 


### PR DESCRIPTION
Fixes: https://github.com/ros-controls/ros2_controllers/issues/1574
Fixes: https://github.com/ros-controls/ros2_controllers/issues/1669

Apart from this, I've seen a possible vulnerability with the current API, I'll open a different PR  to handle this one.