### PR TITLE
Add new API for the RealtimePublisher

### DIFF
--- a/realtime_tools/include/realtime_tools/realtime_publisher.hpp
+++ b/realtime_tools/include/realtime_tools/realtime_publisher.hpp
@@ -44,6 +44,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <utility>
 
 #include "rclcpp/publisher.hpp"
 
@@ -62,7 +63,8 @@ public:
 
   RCLCPP_SMART_PTR_DEFINITIONS(RealtimePublisher<MessageT>)
 
-  /// The msg_ variable contains the data that will get published on the ROS topic.
+  [[deprecated(
+    "This variable is deprecated, it is recommended to use the try_publish() method instead.")]]
   MessageT msg_;
 
   /**
@@ -129,33 +131,71 @@ public:
   *
   * \return true if the lock was successfully acquired, false otherwise
   */
+  [[deprecated(
+    "Use try_publish() method instead of this method. This method may be removed in future "
+    "versions.")]]
   bool trylock()
   {
-    if (turn_.load(std::memory_order_acquire) == State::REALTIME && msg_mutex_.try_lock()) {
-      return true;
-    } else {
-      return false;
-    }
+    return turn_.load(std::memory_order_acquire) == State::REALTIME && msg_mutex_.try_lock();
   }
 
   /**
-   * \brief Try to get the data lock from realtime and publish the given message
+   * \brief Check if the realtime publisher is in a state to publish messages
+   * \return true if the publisher is in a state to publish messages
+   * \note The msg_ variable can be safely accessed if this function returns true
+  */
+  bool can_publish() const
+  {
+    std::unique_lock<std::mutex> lock(msg_mutex_, std::try_to_lock);
+    return turn_.load(std::memory_order_acquire) == State::REALTIME && lock.owns_lock();
+  }
+
+  /**
+   * \brief Try to publish the given message
    *
-   * Tries to gain unique access to msg_ variable. If this succeeds
-   * update the msg_ variable and call unlockAndPublish
+   * This method attempts to publish the given message if the publisher is in a state to do so.
+   * It uses a try_lock to avoid blocking if the mutex is already held by another thread.
    *
    * \param [in] msg The message to publish
-   * \return false in case no lock for the realtime variable is acquired. This implies the message will not be published.
+   * \return true if the message was successfully published, false otherwise
    */
+  bool try_publish(const MessageT & msg)
+  {
+    if (can_publish()) {
+      std::unique_lock<std::mutex> lock(msg_mutex_, std::try_to_lock);
+      if (lock.owns_lock()) {
+        {
+          std::unique_lock<std::mutex> scoped_lock(std::move(lock));
+          msg_ = msg;
+          turn_.store(State::NON_REALTIME, std::memory_order_release);
+        }
+        updated_cond_.notify_one();  // Notify the publishing thread
+        return true;
+      } else {
+        // The lock was not acquired, so we cannot publish
+        return false;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * \brief Try to publish the given message (deprecated)
+   * \deprecated This method is deprecated and should be replaced with try_publish()
+   *
+   * This method is deprecated and should be replaced with try_publish().
+   * It attempts to publish the given message if the publisher is in a state to do so.
+   * It uses a try_lock to avoid blocking if the mutex is already held by another thread.
+   *
+   * \param [in] msg The message to publish
+   * \return true if the message was successfully published, false otherwise
+   */
+  [[deprecated(
+    "Use try_publish() method instead of this method. This method may be removed in future "
+    "versions.")]]
   bool tryPublish(const MessageT & msg)
   {
-    if (!trylock()) {
-      return false;
-    }
-
-    msg_ = msg;
-    unlockAndPublish();
-    return true;
+    return try_publish(msg);
   }
 
   /**
@@ -165,6 +205,9 @@ public:
    * variable, the lock has to be released for the message to get
    * published on the specified topic.
    */
+  [[deprecated(
+    "Use the try_publish() method to publish the message instead of using this method. This method "
+    "may be removed in future versions.")]]
   void unlockAndPublish()
   {
     turn_.store(State::NON_REALTIME, std::memory_order_release);
@@ -177,12 +220,21 @@ public:
    * This blocking call acquires exclusive access to the msg_ variable.
    * Use trylock() for non-blocking attempts to acquire the lock.
    */
-  void lock() { msg_mutex_.lock(); }
+  [[deprecated(
+    "Use the try_publish() method to publish the message instead of using this method. This method "
+    "may be removed in future versions.")]]
+  void lock()
+  {
+    msg_mutex_.lock();
+  }
 
   /**
    * \brief Unlocks the data without publishing anything
    *
    */
+  [[deprecated(
+    "Use the try_publish() method to publish the message instead of using this method. This method "
+    "may be removed in future versions.")]]
   void unlock()
   {
     msg_mutex_.unlock();
@@ -192,6 +244,12 @@ public:
   std::thread & get_thread() { return thread_; }
 
   const std::thread & get_thread() const { return thread_; }
+
+  const MessageT & get_msg() const { return msg_; }
+
+  std::mutex & get_mutex() { return msg_mutex_; }
+
+  const std::mutex & get_mutex() const { return msg_mutex_; }
 
 private:
   // non-copyable
@@ -240,7 +298,7 @@ private:
 
   std::thread thread_;
 
-  std::mutex msg_mutex_;  // Protects msg_
+  mutable std::mutex msg_mutex_;  // Protects msg_
   std::condition_variable updated_cond_;
 
   enum class State : int { REALTIME, NON_REALTIME, LOOP_NOT_STARTED };

--- a/realtime_tools/test/realtime_publisher_tests.cpp
+++ b/realtime_tools/test/realtime_publisher_tests.cpp
@@ -132,3 +132,45 @@ TEST(RealtimePublisher, rt_try_publish)
   EXPECT_STREQ(expected_msg, str_callback.msg_.string_value.c_str());
   rclcpp::shutdown();
 }
+
+TEST(RealtimePublisher, rt_can_try_publish)
+{
+  rclcpp::init(0, nullptr);
+  const size_t ATTEMPTS = 10;
+  const std::chrono::milliseconds DELAY(250);
+
+  const char * expected_msg = "Hello World";
+  auto node = std::make_shared<rclcpp::Node>("construct_move_destruct");
+  rclcpp::QoS qos(10);
+  qos.reliable().transient_local();
+  auto pub = node->create_publisher<StringMsg>("~/rt_publish", qos);
+  RealtimePublisher<StringMsg> rt_pub(pub);
+  ASSERT_TRUE(rt_pub.can_publish());
+
+  // try publish a latched message
+  bool publish_success = false;
+  for (std::size_t i = 0; i < ATTEMPTS; ++i) {
+    StringMsg msg;
+    msg.string_value = expected_msg;
+
+    if (rt_pub.can_publish()) {
+      ASSERT_TRUE(rt_pub.try_publish(msg));
+      publish_success = true;
+    }
+    std::this_thread::sleep_for(DELAY);
+  }
+  ASSERT_TRUE(publish_success);
+
+  // make sure subscriber gets it
+  StringCallback str_callback;
+
+  auto sub = node->create_subscription<StringMsg>(
+    "~/rt_publish", qos,
+    std::bind(&StringCallback::callback, &str_callback, std::placeholders::_1));
+  for (size_t i = 0; i < ATTEMPTS && str_callback.msg_.string_value.empty(); ++i) {
+    rclcpp::spin_some(node);
+    std::this_thread::sleep_for(DELAY);
+  }
+  EXPECT_STREQ(expected_msg, str_callback.msg_.string_value.c_str());
+  rclcpp::shutdown();
+}


### PR DESCRIPTION
This should avoid any dangling threads of the RealtimePublisher and handling lock and unlock is not safe in most of the situation, so, I've added can_publish and try_publish methods