### PR TITLE
Use `Boost::boost` instead of ${Boost_LIBRARIES}

### DIFF
--- a/realtime_tools/CMakeLists.txt
+++ b/realtime_tools/CMakeLists.txt
@@ -80,7 +80,7 @@ if(BUILD_TESTING)
   target_link_libraries(realtime_buffer_tests realtime_tools)
 
   ament_add_gmock(lock_free_queue_tests test/lock_free_queue_tests.cpp)
-  target_link_libraries(lock_free_queue_tests realtime_tools ${Boost_LIBRARIES})
+  target_link_libraries(lock_free_queue_tests realtime_tools Boost::boost)
   if(UNIX)
     target_link_libraries(lock_free_queue_tests atomic)
   endif()

--- a/realtime_tools/CMakeLists.txt
+++ b/realtime_tools/CMakeLists.txt
@@ -44,7 +44,7 @@ target_include_directories(realtime_tools PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/realtime_tools>
 )
-target_link_libraries(realtime_tools PUBLIC rclcpp::rclcpp rclcpp_action::rclcpp_action rcpputils::rcpputils Threads::Threads)
+target_link_libraries(realtime_tools PUBLIC rclcpp::rclcpp rclcpp_action::rclcpp_action rcpputils::rcpputils Threads::Threads Boost::boost)
 if(UNIX)
   target_link_libraries(realtime_tools PUBLIC cap)
 endif()


### PR DESCRIPTION
Related to comment here: https://github.com/ros-controls/realtime_tools/pull/331#discussion_r2101051854