### PR TITLE
Change default mutex of `RealtimeThreadSafeBox` and add more aliases

### DIFF
--- a/realtime_tools/include/realtime_tools/realtime_box.hpp
+++ b/realtime_tools/include/realtime_tools/realtime_box.hpp
@@ -44,7 +44,7 @@ namespace realtime_tools
 
 // Provide backward-compatibility for the old RealtimeBox class
 template <class T, typename mutex_type = std::mutex>
-using RealtimeBoxBase = RealtimeThreadSafeBoxBase<T, mutex_type>;
+using RealtimeBoxBase = RealtimeThreadSafeBox<T, mutex_type>;
 
 template <typename T>
 using RealtimeBoxStandard = RealtimeBoxBase<T, std::mutex>;

--- a/realtime_tools/include/realtime_tools/realtime_box.hpp
+++ b/realtime_tools/include/realtime_tools/realtime_box.hpp
@@ -42,8 +42,18 @@
 namespace realtime_tools
 {
 
+// Provide backward-compatibility for the old RealtimeBox class
+template <class T, typename mutex_type = std::mutex>
+using RealtimeBoxBase = RealtimeThreadSafeBoxBase<T, mutex_type>;
+
 template <typename T>
-using RealtimeBox = RealtimeThreadSafeBox<T>;
+using RealtimeBoxStandard = RealtimeBoxBase<T, std::mutex>;
+
+template <typename T>
+using RealtimeBoxRecursive = RealtimeBoxBase<T, std::recursive_mutex>;
+
+template <typename T>
+using RealtimeBox = RealtimeBoxStandard<T>;
 
 }  // namespace realtime_tools
 

--- a/realtime_tools/include/realtime_tools/realtime_thread_safe_box.hpp
+++ b/realtime_tools/include/realtime_tools/realtime_thread_safe_box.hpp
@@ -62,7 +62,7 @@ constexpr auto is_ptr_or_smart_ptr = rcpputils::is_pointer<T>::value;
     Only use the get/set methods that take function pointer for accessing the internal value.
 */
 template <class T, typename mutex_type = DEFAULT_MUTEX>
-class RealtimeThreadSafeBoxBase
+class RealtimeThreadSafeBox
 {
   static_assert(std::is_copy_constructible_v<T>, "Passed type must be copy constructible");
 
@@ -70,11 +70,11 @@ public:
   using mutex_t = mutex_type;
   using type = T;
   // Provide various constructors
-  constexpr explicit RealtimeThreadSafeBoxBase(const T & init = T{}) : value_(init) {}
-  constexpr explicit RealtimeThreadSafeBoxBase(const T && init) : value_(std::move(init)) {}
+  constexpr explicit RealtimeThreadSafeBox(const T & init = T{}) : value_(init) {}
+  constexpr explicit RealtimeThreadSafeBox(const T && init) : value_(std::move(init)) {}
 
   // Copy constructor
-  constexpr RealtimeThreadSafeBoxBase(const RealtimeThreadSafeBoxBase & o)
+  constexpr RealtimeThreadSafeBox(const RealtimeThreadSafeBox & o)
   {
     // Lock the other box mutex
     std::unique_lock<mutex_t> lock(o.lock_);
@@ -83,7 +83,7 @@ public:
   }
 
   // Copy assignment constructor
-  constexpr RealtimeThreadSafeBoxBase & operator=(const RealtimeThreadSafeBoxBase & o)
+  constexpr RealtimeThreadSafeBox & operator=(const RealtimeThreadSafeBox & o)
   {
     // Check for self assignment (and a potential deadlock)
     if (&o != this) {
@@ -96,7 +96,7 @@ public:
     return *this;
   }
 
-  constexpr RealtimeThreadSafeBoxBase(RealtimeThreadSafeBoxBase && o)
+  constexpr RealtimeThreadSafeBox(RealtimeThreadSafeBox && o)
   {
     // Lock the other box mutex
     std::unique_lock<mutex_t> lock(o.lock_);
@@ -106,14 +106,14 @@ public:
 
   // Only enabled for types that can be constructed from an initializer list
   template <typename U = T>
-  constexpr RealtimeThreadSafeBoxBase(
+  constexpr RealtimeThreadSafeBox(
     const std::initializer_list<U> & init,
     std::enable_if_t<std::is_constructible_v<U, std::initializer_list<U>>>)
   : value_(init)
   {
   }
 
-  constexpr RealtimeThreadSafeBoxBase & operator=(RealtimeThreadSafeBoxBase && o)
+  constexpr RealtimeThreadSafeBox & operator=(RealtimeThreadSafeBox && o)
   {
     // Check for self assignment (and a potential deadlock)
     if (&o != this) {
@@ -303,14 +303,10 @@ private:
 
 // Provide specialisations for different mutex types
 template <typename T>
-using RealtimeThreadSafeBoxStandard = RealtimeThreadSafeBoxBase<T, std::mutex>;
+using RealtimeThreadSafeBoxStandard = RealtimeThreadSafeBox<T, std::mutex>;
 
 template <typename T>
-using RealtimeThreadSafeBoxRecursive = RealtimeThreadSafeBoxBase<T, std::recursive_mutex>;
-
-// This is the specialisation we recommend to use in the end
-template <typename T>
-using RealtimeThreadSafeBox = RealtimeThreadSafeBoxBase<T, DEFAULT_MUTEX>;
+using RealtimeThreadSafeBoxRecursive = RealtimeThreadSafeBox<T, std::recursive_mutex>;
 
 }  // namespace realtime_tools
 

--- a/realtime_tools/include/realtime_tools/realtime_thread_safe_box.hpp
+++ b/realtime_tools/include/realtime_tools/realtime_thread_safe_box.hpp
@@ -299,14 +299,11 @@ private:
   mutable mutex_t lock_;
 };
 
-// Introduce some easier to use names
-
-// Provide specialisations for different mutex types
-template <typename T>
-using RealtimeThreadSafeBoxStandard = RealtimeThreadSafeBox<T, std::mutex>;
+// Provide specialisations for other mutex types
 
 template <typename T>
-using RealtimeThreadSafeBoxRecursive = RealtimeThreadSafeBox<T, std::recursive_mutex>;
+using RealtimeThreadSafeBoxRecursive =
+  RealtimeThreadSafeBox<T, realtime_tools::prio_inherit_recursive_mutex>;
 
 }  // namespace realtime_tools
 

--- a/realtime_tools/include/realtime_tools/realtime_thread_safe_box.hpp
+++ b/realtime_tools/include/realtime_tools/realtime_thread_safe_box.hpp
@@ -310,7 +310,7 @@ using RealtimeThreadSafeBoxRecursive = RealtimeThreadSafeBoxBase<T, std::recursi
 
 // This is the specialisation we recommend to use in the end
 template <typename T>
-using RealtimeThreadSafeBox = RealtimeThreadSafeBoxStandard<T>;
+using RealtimeThreadSafeBox = RealtimeThreadSafeBoxBase<T>;
 
 }  // namespace realtime_tools
 

--- a/realtime_tools/include/realtime_tools/realtime_thread_safe_box.hpp
+++ b/realtime_tools/include/realtime_tools/realtime_thread_safe_box.hpp
@@ -46,7 +46,7 @@
 #define RECURSIVE_MUTEX realtime_tools::prio_inherit_recursive_mutex
 #else
 #define DEFAULT_MUTEX std::mutex
-#define DEFAULT_MUTEX std::recursive_mutex
+#define RECURSIVE_MUTEX std::recursive_mutex
 #endif
 
 namespace realtime_tools

--- a/realtime_tools/include/realtime_tools/realtime_thread_safe_box.hpp
+++ b/realtime_tools/include/realtime_tools/realtime_thread_safe_box.hpp
@@ -310,7 +310,7 @@ using RealtimeThreadSafeBoxRecursive = RealtimeThreadSafeBoxBase<T, std::recursi
 
 // This is the specialisation we recommend to use in the end
 template <typename T>
-using RealtimeThreadSafeBox = RealtimeThreadSafeBoxBase<T>;
+using RealtimeThreadSafeBox = RealtimeThreadSafeBoxBase<T, DEFAULT_MUTEX>;
 
 }  // namespace realtime_tools
 

--- a/realtime_tools/include/realtime_tools/realtime_thread_safe_box.hpp
+++ b/realtime_tools/include/realtime_tools/realtime_thread_safe_box.hpp
@@ -43,8 +43,10 @@
 #ifndef _WIN32
 #include "realtime_tools/mutex.hpp"
 #define DEFAULT_MUTEX realtime_tools::prio_inherit_mutex
+#define RECURSIVE_MUTEX realtime_tools::prio_inherit_recursive_mutex
 #else
 #define DEFAULT_MUTEX std::mutex
+#define DEFAULT_MUTEX std::recursive_mutex
 #endif
 
 namespace realtime_tools
@@ -302,8 +304,7 @@ private:
 // Provide specialisations for other mutex types
 
 template <typename T>
-using RealtimeThreadSafeBoxRecursive =
-  RealtimeThreadSafeBox<T, realtime_tools::prio_inherit_recursive_mutex>;
+using RealtimeThreadSafeBoxRecursive = RealtimeThreadSafeBox<T, RECURSIVE_MUTEX>;
 
 }  // namespace realtime_tools
 


### PR DESCRIPTION
Change default mutex of `RealtimeThreadSafeBox` to use `realtime_tools::prio_inherit_mutex` on non-win systems and improve backwards compatibility by adding more aliasesto the old RealtimeBox class(es)