### PR TITLE
Fix macOS compatibility issues in realtime_tools package

### DIFF
--- a/realtime_tools/CMakeLists.txt
+++ b/realtime_tools/CMakeLists.txt
@@ -44,8 +44,13 @@ target_include_directories(realtime_tools PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/realtime_tools>
 )
+<<<<<<< HEAD:realtime_tools/CMakeLists.txt
 target_link_libraries(realtime_tools PUBLIC rclcpp::rclcpp rclcpp_action::rclcpp_action rcpputils::rcpputils Threads::Threads Boost::boost)
 if(UNIX)
+=======
+ament_target_dependencies(realtime_tools PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
+if(UNIX AND NOT APPLE)
+>>>>>>> b666f29 (Fix macOS compatibility in realtime_tools):CMakeLists.txt
   target_link_libraries(realtime_tools PUBLIC cap)
 endif()
 
@@ -58,8 +63,13 @@ target_include_directories(thread_priority PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/realtime_tools>
 )
+<<<<<<< HEAD:realtime_tools/CMakeLists.txt
 target_link_libraries(thread_priority PUBLIC rclcpp::rclcpp rclcpp_action::rclcpp_action rcpputils::rcpputils Threads::Threads)
 if(UNIX)
+=======
+ament_target_dependencies(thread_priority PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
+if(UNIX AND NOT APPLE)
+>>>>>>> b666f29 (Fix macOS compatibility in realtime_tools):CMakeLists.txt
   target_link_libraries(thread_priority PUBLIC cap)
 endif()
 
@@ -80,9 +90,21 @@ if(BUILD_TESTING)
   target_link_libraries(realtime_buffer_tests realtime_tools)
 
   ament_add_gmock(lock_free_queue_tests test/lock_free_queue_tests.cpp)
+<<<<<<< HEAD:realtime_tools/CMakeLists.txt
   target_link_libraries(lock_free_queue_tests realtime_tools Boost::boost)
   if(UNIX)
     target_link_libraries(lock_free_queue_tests atomic)
+=======
+  if(WIN32)
+    # atomic is not found on Windows, but also not needed
+    target_link_libraries(lock_free_queue_tests realtime_tools Boost::boost)
+  elseif(APPLE)
+    # On macOS, atomic lib is generally not needed
+    target_link_libraries(lock_free_queue_tests realtime_tools Boost::boost)
+  else()
+    # without adding atomic, clang throws a linker error
+    target_link_libraries(lock_free_queue_tests realtime_tools atomic Boost::boost)
+>>>>>>> b666f29 (Fix macOS compatibility in realtime_tools):CMakeLists.txt
   endif()
 
   ament_add_gmock(realtime_publisher_tests

--- a/realtime_tools/include/realtime_tools/mutex.hpp
+++ b/realtime_tools/include/realtime_tools/mutex.hpp
@@ -52,12 +52,20 @@ struct recursive_mutex_type_t
 
 struct stalled_robustness_t
 {
-  static constexpr int value = PTHREAD_MUTEX_STALLED;
+  #ifdef PTHREAD_MUTEX_STALLED
+    static constexpr int value = PTHREAD_MUTEX_STALLED;
+  #else
+    static constexpr int value = 0;
+  #endif
 };
 
 struct robust_robustness_t
 {
-  static constexpr int value = PTHREAD_MUTEX_ROBUST;
+  #ifdef PTHREAD_MUTEX_STALLED
+    static constexpr int value = PTHREAD_MUTEX_STALLED;
+  #else
+    static constexpr int value = 0;
+  #endif
 };
 /**
  * @brief A class template that provides a pthread mutex with the priority inheritance protocol
@@ -109,10 +117,15 @@ public:
     }
 
     // Set the mutex attribute robustness to MutexRobustness
-    const auto res_robust = pthread_mutexattr_setrobust(&attr, MutexRobustness::value);
-    if (res_robust != 0) {
-      throw std::system_error(res_robust, std::system_category(), "Failed to set mutex robustness");
-    }
+    #if defined(__linux__)
+      const auto res_robust = pthread_mutexattr_setrobust(&attr, MutexRobustness::value);
+      if (res_robust != 0) {
+        throw std::system_error(res_robust, std::system_category(), "Failed to set mutex robustness");
+      }
+    #else
+      // On platforms like macOS, pthread_mutexattr_setrobust is not available,
+      // so skip this step
+    #endif
 
     // Initialize the mutex with the attributes
     const auto res_init = pthread_mutex_init(&mutex_, &attr);
@@ -142,13 +155,19 @@ public:
       return;
     }
     if (res == EOWNERDEAD) {
-      const auto res_consistent = pthread_mutex_consistent(&mutex_);
-      if (res_consistent != 0) {
-        throw std::runtime_error(
-          std::string("Failed to make mutex consistent : ") + std::strerror(res_consistent));
-      }
-      std::cerr << "Mutex owner died, but the mutex is consistent now. This shouldn't happen!"
-                << std::endl;
+      #if defined(__linux__)
+        const auto res_consistent = pthread_mutex_consistent(&mutex_);
+        if (res_consistent != 0) {
+          throw std::runtime_error(
+            std::string("Failed to make mutex consistent : ") + std::strerror(res_consistent));
+        }
+        std::cerr << "Mutex owner died, but the mutex is consistent now. This shouldn't happen!"
+                  << std::endl;
+      #else
+        // On platforms without pthread_mutex_consistent support, just log a warning
+        std::cerr << "Mutex owner died, but pthread_mutex_consistent is not supported on this platform."
+                  << std::endl;
+      #endif
     } else if (res == EDEADLK) {
       throw std::system_error(res, std::system_category(), "Deadlock detected");
     } else {
@@ -174,13 +193,18 @@ public:
     if (res == EBUSY) {
       return false;
     } else if (res == EOWNERDEAD) {
-      const auto res_consistent = pthread_mutex_consistent(&mutex_);
-      if (res_consistent != 0) {
-        throw std::runtime_error(
-          std::string("Failed to make mutex consistent : ") + std::strerror(res_consistent));
-      }
-      std::cerr << "Mutex owner died, but the mutex is consistent now. This shouldn't happen!"
-                << std::endl;
+        #if defined(__linux__)
+          const auto res_consistent = pthread_mutex_consistent(&mutex_);
+          if (res_consistent != 0) {
+            throw std::runtime_error(
+              std::string("Failed to make mutex consistent : ") + std::strerror(res_consistent));
+          }
+          std::cerr << "Mutex owner died, but the mutex is consistent now. This shouldn't happen!"
+                    << std::endl;
+        #else
+          std::cerr << "Mutex owner died, but pthread_mutex_consistent is not supported on this platform."
+                    << std::endl;
+        #endif
     } else if (res == EDEADLK) {
       throw std::system_error(res, std::system_category(), "Deadlock detected");
     } else {


### PR DESCRIPTION
in source and cmakefile:
- Enable successful compilation and runtime behavior of realtime_tools on macOS, enhancing cross-platform support.
- Link against the atomic library on non-Windows platforms to resolve linker errors with clang.

in tests:
- Fix missing pthread functions and constants on macOS (pthread_mutex_consistent, pthread_mutexattr_setrobust, PTHREAD_MUTEX_STALLED) using conditional compilation.
- Adjust mutex robustness handling to be compatible with macOS pthread implementation.

thanks a lot @traversaro for the original patch that this PR builds upon to fix macOS compatibility issues.