### PR TITLE
Fix `github.ref` check for concurrency settings

### DIFF
--- a/.github/workflows/humble-abi-compatibility.yml
+++ b/.github/workflows/humble-abi-compatibility.yml
@@ -6,9 +6,9 @@ on:
       - humble
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on humble branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   abi_check:

--- a/.github/workflows/humble-binary-build.yml
+++ b/.github/workflows/humble-binary-build.yml
@@ -15,9 +15,9 @@ on:
     - cron: '03 1 * * MON-FRI'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on humble branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   binary:

--- a/.github/workflows/humble-binary-downstream-build.yml
+++ b/.github/workflows/humble-binary-downstream-build.yml
@@ -12,9 +12,9 @@ on:
       - humble
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on humble branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   build-downstream:

--- a/.github/workflows/humble-coverage-build.yml
+++ b/.github/workflows/humble-coverage-build.yml
@@ -9,9 +9,9 @@ on:
       - humble
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on humble branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   coverage:

--- a/.github/workflows/humble-debian-build.yml
+++ b/.github/workflows/humble-debian-build.yml
@@ -9,9 +9,9 @@ on:
     - cron: '33 2 * * MON-FRI'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on humble branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   debian_semi_binary_build:

--- a/.github/workflows/humble-rhel-semi-binary-build.yml
+++ b/.github/workflows/humble-rhel-semi-binary-build.yml
@@ -9,9 +9,9 @@ on:
     - cron: '03 3 * * MON-FRI'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on humble branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   rhel_semi_binary_build:

--- a/.github/workflows/jazzy-abi-compatibility.yml
+++ b/.github/workflows/jazzy-abi-compatibility.yml
@@ -6,9 +6,9 @@ on:
       - jazzy
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on jazzy branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   abi_check:

--- a/.github/workflows/jazzy-binary-build.yml
+++ b/.github/workflows/jazzy-binary-build.yml
@@ -15,9 +15,9 @@ on:
     - cron: '03 1 * * MON-FRI'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on jazzy branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   binary:

--- a/.github/workflows/jazzy-binary-downstream-build.yml
+++ b/.github/workflows/jazzy-binary-downstream-build.yml
@@ -12,9 +12,9 @@ on:
       - jazzy
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on jazzy branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   build-downstream:

--- a/.github/workflows/jazzy-coverage-build.yml
+++ b/.github/workflows/jazzy-coverage-build.yml
@@ -9,9 +9,9 @@ on:
       - jazzy
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on jazzy branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   coverage:

--- a/.github/workflows/jazzy-debian-build.yml
+++ b/.github/workflows/jazzy-debian-build.yml
@@ -9,9 +9,9 @@ on:
     - cron: '33 2 * * MON-FRI'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on jazzy branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   debian_semi_binary_build:

--- a/.github/workflows/jazzy-rhel-semi-binary-build.yml
+++ b/.github/workflows/jazzy-rhel-semi-binary-build.yml
@@ -9,9 +9,9 @@ on:
     - cron: '03 3 * * MON-FRI'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on jazzy branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   rhel_semi_binary_build:

--- a/.github/workflows/jazzy-rosdoc2.yml
+++ b/.github/workflows/jazzy-rosdoc2.yml
@@ -11,9 +11,9 @@ on:
       - package.xml
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on jazzy branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   check:

--- a/.github/workflows/jazzy-semi-binary-build.yml
+++ b/.github/workflows/jazzy-semi-binary-build.yml
@@ -15,9 +15,9 @@ on:
     - cron: '03 1 * * MON-FRI'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on jazzy branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   binary:

--- a/.github/workflows/rolling-abi-compatibility.yml
+++ b/.github/workflows/rolling-abi-compatibility.yml
@@ -6,9 +6,9 @@ on:
       - master
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on master branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   abi_check:

--- a/.github/workflows/rolling-binary-build-win.yml
+++ b/.github/workflows/rolling-binary-build-win.yml
@@ -17,9 +17,9 @@ on:
   #     - created
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on master branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   binary-windows:

--- a/.github/workflows/rolling-binary-build.yml
+++ b/.github/workflows/rolling-binary-build.yml
@@ -15,9 +15,9 @@ on:
     - cron: '03 1 * * MON-FRI'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on master branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   binary:

--- a/.github/workflows/rolling-binary-downstream-build.yml
+++ b/.github/workflows/rolling-binary-downstream-build.yml
@@ -12,9 +12,9 @@ on:
       - master
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on master branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   build-downstream:

--- a/.github/workflows/rolling-compatibility-build.yml
+++ b/.github/workflows/rolling-compatibility-build.yml
@@ -12,9 +12,9 @@ on:
       - master
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on master branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   build:

--- a/.github/workflows/rolling-coverage-build.yml
+++ b/.github/workflows/rolling-coverage-build.yml
@@ -9,9 +9,9 @@ on:
       - master
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on master branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   coverage:

--- a/.github/workflows/rolling-debian-build.yml
+++ b/.github/workflows/rolling-debian-build.yml
@@ -9,9 +9,9 @@ on:
     - cron: '33 2 * * MON-FRI'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on master branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   debian_semi_binary_build:

--- a/.github/workflows/rolling-rhel-semi-binary-build.yml
+++ b/.github/workflows/rolling-rhel-semi-binary-build.yml
@@ -9,9 +9,9 @@ on:
     - cron: '03 3 * * MON-FRI'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on master branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   rhel_semi_binary_build:

--- a/.github/workflows/rolling-rosdoc2.yml
+++ b/.github/workflows/rolling-rosdoc2.yml
@@ -11,9 +11,9 @@ on:
       - package.xml
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on master branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   check:

--- a/.github/workflows/rolling-semi-binary-build.yml
+++ b/.github/workflows/rolling-semi-binary-build.yml
@@ -15,9 +15,9 @@ on:
     - cron: '03 1 * * MON-FRI'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on master branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   binary:


### PR DESCRIPTION
`github.ref`:
> The ref given is fully-formed, meaning that for branches the format is refs/heads/<branch_name>.
which means the leading slash was wrong, see [this canceled job for example](https://github.com/ros-controls/kinematics_interface/actions/runs/17260587722).

https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context