### PR TITLE
Fix the failing ament_cppcheck in realtime_thread_safe_box

### DIFF
--- a/realtime_tools/include/realtime_tools/realtime_thread_safe_box.hpp
+++ b/realtime_tools/include/realtime_tools/realtime_thread_safe_box.hpp
@@ -220,8 +220,8 @@ public:
    * @brief wait until the mutex could be locked and access the content (rw)
    * @note Overload to allow setting pointer types to nullptr directly.
    */
-  template <typename U = T>
-  typename std::enable_if_t<is_ptr_or_smart_ptr<U>, void> set(std::nullptr_t)
+  template <typename U = T, typename = std::enable_if_t<is_ptr_or_smart_ptr<U>>>
+  void set(std::nullptr_t)
   {
     std::lock_guard<mutex_t> guard(lock_);
     value_ = nullptr;


### PR DESCRIPTION
Fixes:
```
ament_cppcheck...........................................................Failed
- hook id: ament_cppcheck
- exit code: 1

No problems found
No problems found
[realtime_tools/include/realtime_tools/realtime_thread_safe_box.hpp:227]: (error: missingReturn) Found a exit path from function with non-void return type that has missing return statement
1 errors
No problems found
No problems found

ament_cpplint............................................................Passed
```