### PR TITLE
Deprecate `msg_` field

### DIFF
--- a/realtime_tools/include/realtime_tools/realtime_publisher.hpp
+++ b/realtime_tools/include/realtime_tools/realtime_publisher.hpp
@@ -63,6 +63,8 @@ public:
 
   RCLCPP_SMART_PTR_DEFINITIONS(RealtimePublisher<MessageT>)
 
+  [[deprecated(
+    "This variable is deprecated, it is recommended to use the try_publish() method instead.")]]
   MessageT msg_;
 
   /**
@@ -74,6 +76,13 @@ public:
    *
    * \param publisher the ROS publisher to wrap
    */
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#else
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   explicit RealtimePublisher(PublisherSharedPtr publisher)
   : publisher_(publisher), is_running_(false), keep_running_(true), turn_(State::LOOP_NOT_STARTED)
   {
@@ -102,6 +111,11 @@ public:
       thread_.join();
     }
   }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#else
+#pragma GCC diagnostic pop
+#endif
 
   /**
    * \brief Stop the realtime publisher
@@ -161,7 +175,19 @@ public:
     if (can_publish(lock)) {
       {
         std::unique_lock<std::mutex> scoped_lock(std::move(lock));
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#else
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
         msg_ = msg;
+#ifdef _MSC_VER
+#pragma warning(pop)
+#else
+#pragma GCC diagnostic pop
+#endif
         turn_.store(State::NON_REALTIME, std::memory_order_release);
       }
       updated_cond_.notify_one();  // Notify the publishing thread
@@ -238,8 +264,19 @@ public:
   std::thread & get_thread() { return thread_; }
 
   const std::thread & get_thread() const { return thread_; }
-
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#else
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   const MessageT & get_msg() const { return msg_; }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#else
+#pragma GCC diagnostic pop
+#endif
 
   std::mutex & get_mutex() { return msg_mutex_; }
 
@@ -286,7 +323,19 @@ private:
         // Locks msg_ and copies it to outgoing
         std::unique_lock<std::mutex> lock_(msg_mutex_);
         updated_cond_.wait(lock_, [&] { return turn_ == State::NON_REALTIME || !keep_running_; });
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#else
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
         outgoing = msg_;
+#ifdef _MSC_VER
+#pragma warning(pop)
+#else
+#pragma GCC diagnostic pop
+#endif
       }
 
       // Sends the outgoing message


### PR DESCRIPTION
I found a way in deprecating it without annoying deprecation warnings of the class itself.
Partially reverts #355 

Throws deprecation notices with current ros2_controller, but does not after
https://github.com/ros-controls/ros2_controllers/pull/1947