### PR TITLE
Deprecate `get_msg` method or RT publisher

### DIFF
--- a/realtime_tools/include/realtime_tools/realtime_publisher.hpp
+++ b/realtime_tools/include/realtime_tools/realtime_publisher.hpp
@@ -264,6 +264,12 @@ public:
   std::thread & get_thread() { return thread_; }
 
   const std::thread & get_thread() const { return thread_; }
+
+  [[deprecated(
+    "This getter method will be removed. It is recommended to use the try_publish() instead of "
+    "accessing the msg_ variable.")]]
+  const MessageT & get_msg() const
+  {
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4996)
@@ -271,12 +277,13 @@ public:
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
-  const MessageT & get_msg() const { return msg_; }
+    return msg_;
 #ifdef _MSC_VER
 #pragma warning(pop)
 #else
 #pragma GCC diagnostic pop
 #endif
+  }
 
   std::mutex & get_mutex() { return msg_mutex_; }
 


### PR DESCRIPTION
https://github.com/ros-controls/realtime_tools/pull/371#discussion_r2404367801

and it is not used within this repo.