### PR TITLE
Replace deprecated spin_some in realtime_tools

### DIFF
--- a/realtime_tools/test/realtime_publisher_tests.cpp
+++ b/realtime_tools/test/realtime_publisher_tests.cpp
@@ -88,7 +88,7 @@ TEST(RealtimePublisher, rt_can_try_publish)
   auto sub = node->create_subscription<StringMsg>(
     "~/rt_publish", qos,
     std::bind(&StringCallback::callback, &str_callback, std::placeholders::_1));
-  
+
   rclcpp::executors::SingleThreadedExecutor exec;
   exec.add_node(node);
   for (size_t i = 0; i < ATTEMPTS && str_callback.msg_.string_value.empty(); ++i) {

--- a/realtime_tools/test/realtime_server_goal_handle_tests.cpp
+++ b/realtime_tools/test/realtime_server_goal_handle_tests.cpp
@@ -137,8 +137,8 @@ std::shared_ptr<ClientGoalHandle> send_goal(
       executor.spin_some();
       std::this_thread::sleep_for(DELAY);
     }
-  } 
-  
+  }
+
   if (ac->action_server_is_ready()) {
     Fibonacci::Goal goal;
     goal.order = 10;


### PR DESCRIPTION
# Overview

This PR replaces uses of the deprecated rclcpp::spin_some(node) with rclcpp::executors::SingleThreadedExecutor in the realtime tools tests, addressing issue https://github.com/ros-controls/realtime_tools/issues/411

# What changed

Files changed are:

- realtime_tools/test/realtime_server_goal_handle_tests.cpp
- realtime_tools/test/realtime_publisher_tests.cpp

# Notes for Reviewer

Happy to make any changes that are requested. Please also double check my approach with the spin_some() usage in the TEST(RealtimeServerGoalHandle, set_canceled) test.