### PR TITLE
Cleanup gmock Test Dependencies

### DIFF
--- a/realtime_tools/CMakeLists.txt
+++ b/realtime_tools/CMakeLists.txt
@@ -65,38 +65,38 @@ endif()
 
 # Unit Tests
 if(BUILD_TESTING)
-  find_package(ament_cmake_gmock REQUIRED)
+  find_package(ament_cmake_gtest REQUIRED)
   find_package(lifecycle_msgs REQUIRED)
   find_package(rclcpp_lifecycle REQUIRED)
   find_package(test_msgs REQUIRED)
 
-  ament_add_gmock(thread_priority_tests test/thread_priority_tests.cpp)
+  ament_add_gtest(thread_priority_tests test/thread_priority_tests.cpp)
   target_link_libraries(thread_priority_tests thread_priority)
 
-  ament_add_gmock(realtime_thread_safe_box_tests test/realtime_thread_safe_box_tests.cpp)
+  ament_add_gtest(realtime_thread_safe_box_tests test/realtime_thread_safe_box_tests.cpp)
   target_link_libraries(realtime_thread_safe_box_tests realtime_tools)
 
-  ament_add_gmock(realtime_buffer_tests test/realtime_buffer_tests.cpp)
+  ament_add_gtest(realtime_buffer_tests test/realtime_buffer_tests.cpp)
   target_link_libraries(realtime_buffer_tests realtime_tools)
 
-  ament_add_gmock(lock_free_queue_tests test/lock_free_queue_tests.cpp)
+  ament_add_gtest(lock_free_queue_tests test/lock_free_queue_tests.cpp)
 
   target_link_libraries(lock_free_queue_tests realtime_tools Boost::boost)
   if(UNIX AND NOT APPLE)
     target_link_libraries(lock_free_queue_tests atomic)
   endif()
 
-  ament_add_gmock(realtime_publisher_tests
+  ament_add_gtest(realtime_publisher_tests
                   test/realtime_publisher.test
                   test/realtime_publisher_tests.cpp)
   target_link_libraries(realtime_publisher_tests realtime_tools ${test_msgs_TARGETS})
 
-  ament_add_gmock(realtime_server_goal_handle_tests
+  ament_add_gtest(realtime_server_goal_handle_tests
                   test/realtime_server_goal_handle.test
                   test/realtime_server_goal_handle_tests.cpp)
   target_link_libraries(realtime_server_goal_handle_tests realtime_tools ${test_msgs_TARGETS})
 
-  ament_add_gmock(test_async_function_handler test/test_async_function_handler.cpp)
+  ament_add_gtest(test_async_function_handler test/test_async_function_handler.cpp)
   target_link_libraries(test_async_function_handler
                         realtime_tools
                         thread_priority
@@ -104,7 +104,7 @@ if(BUILD_TESTING)
                         rclcpp_lifecycle::rclcpp_lifecycle)
 
   if(NOT WIN32)
-    ament_add_gmock(realtime_mutex_tests test/realtime_mutex_tests.cpp)
+    ament_add_gtest(realtime_mutex_tests test/realtime_mutex_tests.cpp)
     target_link_libraries(realtime_mutex_tests realtime_tools)
   endif()
 endif()

--- a/realtime_tools/package.xml
+++ b/realtime_tools/package.xml
@@ -26,7 +26,7 @@
   <depend>rclcpp_action</depend>
   <depend>libcap-dev</depend>
 
-  <test_depend>ament_cmake_gmock</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>lifecycle_msgs</test_depend>
   <test_depend>rclcpp_lifecycle</test_depend>
   <test_depend>test_msgs</test_depend>

--- a/realtime_tools/test/lock_free_queue_tests.cpp
+++ b/realtime_tools/test/lock_free_queue_tests.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 #include <thread>
 
 #include <realtime_tools/lock_free_queue.hpp>

--- a/realtime_tools/test/realtime_buffer_tests.cpp
+++ b/realtime_tools/test/realtime_buffer_tests.cpp
@@ -26,7 +26,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 #include <realtime_tools/realtime_buffer.hpp>
 
 using realtime_tools::RealtimeBuffer;

--- a/realtime_tools/test/realtime_mutex_tests.cpp
+++ b/realtime_tools/test/realtime_mutex_tests.cpp
@@ -14,7 +14,7 @@
 
 /// \author Sai Kishor Kothakota
 
-#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 #include <mutex>
 #include <thread>

--- a/realtime_tools/test/realtime_publisher_tests.cpp
+++ b/realtime_tools/test/realtime_publisher_tests.cpp
@@ -26,7 +26,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 #include <chrono>
 #include <memory>

--- a/realtime_tools/test/realtime_server_goal_handle_tests.cpp
+++ b/realtime_tools/test/realtime_server_goal_handle_tests.cpp
@@ -26,7 +26,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 #include <chrono>
 #include <functional>

--- a/realtime_tools/test/realtime_thread_safe_box_tests.cpp
+++ b/realtime_tools/test/realtime_thread_safe_box_tests.cpp
@@ -27,7 +27,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <array>

--- a/realtime_tools/test/test_async_function_handler.cpp
+++ b/realtime_tools/test/test_async_function_handler.cpp
@@ -15,7 +15,7 @@
 #include <limits>
 #include <memory>
 
-#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "rclcpp/node.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "test_async_function_handler.hpp"

--- a/realtime_tools/test/thread_priority_tests.cpp
+++ b/realtime_tools/test/thread_priority_tests.cpp
@@ -28,7 +28,7 @@
 
 // Author: Lennart Nachtigall
 
-#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 #include <thread>
 
 #include <realtime_tools/realtime_helpers.hpp>


### PR DESCRIPTION
# Changes

- something that's slightly been bothering me are the `gmock` test deps, when none of the unit tests are using `gmock`. This PR updates the dependencies so they're `gtest`

# Testing

- passing unit tests

# Notes

- This PR is stacked on top of https://github.com/ros-controls/realtime_tools/pull/459
