### PR TITLE
Wait Free Realtime Publisher

### DIFF
--- a/realtime_tools/CMakeLists.txt
+++ b/realtime_tools/CMakeLists.txt
@@ -89,7 +89,11 @@ if(BUILD_TESTING)
   ament_add_gmock(realtime_publisher_tests
                   test/realtime_publisher.test
                   test/realtime_publisher_tests.cpp)
-  target_link_libraries(realtime_publisher_tests realtime_tools ${test_msgs_TARGETS})
+                target_link_libraries(realtime_publisher_tests realtime_tools ${test_msgs_TARGETS})
+
+                ament_add_gmock(wait_free_publisher_test
+                  test/wait_free_publisher_test.cpp)
+  target_link_libraries(wait_free_publisher_test realtime_tools ${test_msgs_TARGETS})
 
   ament_add_gmock(realtime_server_goal_handle_tests
                   test/realtime_server_goal_handle.test

--- a/realtime_tools/CMakeLists.txt
+++ b/realtime_tools/CMakeLists.txt
@@ -90,9 +90,10 @@ if(BUILD_TESTING)
   ament_add_gmock(realtime_publisher_tests
                   test/realtime_publisher.test
                   test/realtime_publisher_tests.cpp)
-                target_link_libraries(realtime_publisher_tests realtime_tools ${test_msgs_TARGETS})
+  target_link_libraries(realtime_publisher_tests realtime_tools ${test_msgs_TARGETS})
 
-                ament_add_gmock(wait_free_publisher_test
+  ament_add_gmock(wait_free_publisher_test
+                  test/wait_free_publisher_test.test
                   test/wait_free_publisher_test.cpp)
   target_link_libraries(wait_free_publisher_test realtime_tools ${test_msgs_TARGETS})
 

--- a/realtime_tools/CMakeLists.txt
+++ b/realtime_tools/CMakeLists.txt
@@ -21,6 +21,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   rclcpp_action
   Threads
   rcpputils
+  benchmark
 )
 
 find_package(ament_cmake REQUIRED)
@@ -112,6 +113,10 @@ if(BUILD_TESTING)
     target_link_libraries(realtime_mutex_tests realtime_tools)
   endif()
 endif()
+
+# Benchmark Tests
+add_executable(realtime_publishers_benchmark benchmark/realtime_publishers_benchmark.cpp)
+target_link_libraries(realtime_publishers_benchmark benchmark::benchmark realtime_tools)
 
 # Install
 install(

--- a/realtime_tools/CMakeLists.txt
+++ b/realtime_tools/CMakeLists.txt
@@ -117,7 +117,7 @@ endif()
 
 # Benchmark Tests
 add_executable(realtime_publishers_benchmark benchmark/realtime_publishers_benchmark.cpp)
-target_link_libraries(realtime_publishers_benchmark benchmark::benchmark realtime_tools)
+target_link_libraries(realtime_publishers_benchmark benchmark::benchmark realtime_tools ${test_msgs_TARGETS})
 
 # Install
 install(

--- a/realtime_tools/benchmark/realtime_publishers_benchmark.cpp
+++ b/realtime_tools/benchmark/realtime_publishers_benchmark.cpp
@@ -16,8 +16,10 @@
 
 #include <benchmark/benchmark.h>
 
+#include <chrono>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include <test_msgs/msg/empty.hpp>
 
@@ -56,10 +58,13 @@ static void BM_RealtimePublisher(benchmark::State & state)
 BENCHMARK(BM_RealtimePublisher);
 
 // Define another benchmark
+template <std::size_t Capacity>
 static void BM_WaitFreeRealtimePublisher(benchmark::State & state)
 {
+  auto poll_duration_us = state.range(0);
   auto pub = std::make_shared<BenchmarkPublisher<test_msgs::msg::Empty>>();
-  realtime_tools::WaitFreeRealtimePublisher<test_msgs::msg::Empty> rt_pub(pub);
+  realtime_tools::WaitFreeRealtimePublisher<test_msgs::msg::Empty, Capacity> rt_pub(
+    pub, std::chrono::microseconds(poll_duration_us));
 
   test_msgs::msg::Empty msg;
   for (auto _ : state) {
@@ -68,6 +73,35 @@ static void BM_WaitFreeRealtimePublisher(benchmark::State & state)
 
   state.counters["num_publishes"] = pub->count();
 }
-BENCHMARK(BM_WaitFreeRealtimePublisher);
+
+// Custom args generator
+static void MicrosecondSweepArgs(benchmark::internal::Benchmark * b)
+{
+  std::vector<int> microsecond_sweep = {1, 10, 50, 100};
+  for (auto micro : microsecond_sweep) {
+    b->Arg(micro);
+  }
+}
+
+BENCHMARK_TEMPLATE(BM_WaitFreeRealtimePublisher, 1)->Apply(MicrosecondSweepArgs);
+BENCHMARK_TEMPLATE(BM_WaitFreeRealtimePublisher, 2)->Apply(MicrosecondSweepArgs);
+BENCHMARK_TEMPLATE(BM_WaitFreeRealtimePublisher, 5)->Apply(MicrosecondSweepArgs);
+BENCHMARK_TEMPLATE(BM_WaitFreeRealtimePublisher, 10)->Apply(MicrosecondSweepArgs);
+
+static void BM_ManualWaitFreeRealtimePublisher(benchmark::State & state)
+{
+  auto pub = std::make_shared<BenchmarkPublisher<test_msgs::msg::Empty>>();
+  realtime_tools::WaitFreeRealtimePublisher<test_msgs::msg::Empty, 2> rt_pub(
+    pub, std::chrono::microseconds(1));
+
+  test_msgs::msg::Empty msg;
+  for (auto _ : state) {
+    rt_pub.push(msg);
+  }
+
+  state.counters["num_publishes"] = pub->count();
+}
+
+BENCHMARK(BM_ManualWaitFreeRealtimePublisher);
 
 BENCHMARK_MAIN();

--- a/realtime_tools/benchmark/realtime_publishers_benchmark.cpp
+++ b/realtime_tools/benchmark/realtime_publishers_benchmark.cpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2025, Brian Jin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Author: Brian Jin
+
+#include <benchmark/benchmark.h>
+
+#include <string>
+
+#include <realtime_tools/realtime_publisher.hpp>
+#include <realtime_tools/wait_free_realtime_publisher.hpp>
+
+static void BM_StringCreation(benchmark::State & state)
+{
+  for (auto _ : state) std::string empty_string;
+}
+// Register the function as a benchmark
+BENCHMARK(BM_StringCreation);
+
+// Define another benchmark
+static void BM_StringCopy(benchmark::State & state)
+{
+  std::string x = "hello";
+  for (auto _ : state) std::string copy(x);
+}
+BENCHMARK(BM_StringCopy);
+
+BENCHMARK_MAIN();

--- a/realtime_tools/benchmark/realtime_publishers_benchmark.cpp
+++ b/realtime_tools/benchmark/realtime_publishers_benchmark.cpp
@@ -16,24 +16,58 @@
 
 #include <benchmark/benchmark.h>
 
+#include <memory>
 #include <string>
 
+#include <test_msgs/msg/empty.hpp>
+
 #include <realtime_tools/realtime_publisher.hpp>
+#include <realtime_tools/utils/publisher_interface.hpp>
 #include <realtime_tools/wait_free_realtime_publisher.hpp>
 
-static void BM_StringCreation(benchmark::State & state)
+namespace
 {
-  for (auto _ : state) std::string empty_string;
+template <class MessageT>
+class BenchmarkPublisher : public realtime_tools::utils::PublisherInterface<MessageT>
+{
+public:
+  void publish(const MessageT &) override { publish_count_++; }
+
+  double count() const { return publish_count_; }
+
+private:
+  double publish_count_{0.0};
+};
+}  // namespace
+
+static void BM_RealtimePublisher(benchmark::State & state)
+{
+  auto pub = std::make_shared<BenchmarkPublisher<test_msgs::msg::Empty>>();
+  realtime_tools::RealtimePublisher<test_msgs::msg::Empty> rt_pub(pub);
+
+  test_msgs::msg::Empty msg;
+  for (auto _ : state) {
+    rt_pub.try_publish(msg);
+  }
+
+  state.counters["num_publishes"] = pub->count();
 }
 // Register the function as a benchmark
-BENCHMARK(BM_StringCreation);
+BENCHMARK(BM_RealtimePublisher);
 
 // Define another benchmark
-static void BM_StringCopy(benchmark::State & state)
+static void BM_WaitFreeRealtimePublisher(benchmark::State & state)
 {
-  std::string x = "hello";
-  for (auto _ : state) std::string copy(x);
+  auto pub = std::make_shared<BenchmarkPublisher<test_msgs::msg::Empty>>();
+  realtime_tools::WaitFreeRealtimePublisher<test_msgs::msg::Empty> rt_pub(pub);
+
+  test_msgs::msg::Empty msg;
+  for (auto _ : state) {
+    rt_pub.push(msg);
+  }
+
+  state.counters["num_publishes"] = pub->count();
 }
-BENCHMARK(BM_StringCopy);
+BENCHMARK(BM_WaitFreeRealtimePublisher);
 
 BENCHMARK_MAIN();

--- a/realtime_tools/benchmark/realtime_publishers_benchmark.cpp
+++ b/realtime_tools/benchmark/realtime_publishers_benchmark.cpp
@@ -94,7 +94,7 @@ BENCHMARK_TEMPLATE(BM_WaitFreeRealtimePublisher, 5)->Apply(MicrosecondSweepArgs)
 BENCHMARK_TEMPLATE(BM_WaitFreeRealtimePublisher, 10)->Apply(MicrosecondSweepArgs);
 
 ////////////////////////////////////////////////////////////////
-// Manually Configured  WaitFree Realtime Publisher Benchmark
+// Manually Configured WaitFree Realtime Publisher Benchmark
 ////////////////////////////////////////////////////////////////
 static void BM_ManualWaitFreeRealtimePublisher(benchmark::State & state)
 {

--- a/realtime_tools/benchmark/realtime_publishers_benchmark.cpp
+++ b/realtime_tools/benchmark/realtime_publishers_benchmark.cpp
@@ -71,9 +71,7 @@ static void BM_WaitFreeRealtimePublisher(benchmark::State & state)
   auto pub = std::make_shared<BenchmarkPublisher<test_msgs::msg::Empty>>();
   realtime_tools::WaitFreeRealtimePublisher<test_msgs::msg::Empty, Capacity> rt_pub(
     pub, std::chrono::microseconds(poll_duration_us));
-  if (!rt_pub.start()) {
-    throw std::runtime_error("Failed to start WaitFreeRealtimePublisher");
-  }
+  rt_pub.start();
 
   test_msgs::msg::Empty msg;
   for (auto _ : state) {
@@ -104,9 +102,7 @@ static void BM_DefaultWaitFreeRealtimePublisher(benchmark::State & state)
 {
   auto pub = std::make_shared<BenchmarkPublisher<test_msgs::msg::Empty>>();
   realtime_tools::WaitFreeRealtimePublisher<test_msgs::msg::Empty> rt_pub(pub);
-  if (!rt_pub.start()) {
-    throw std::runtime_error("Failed to start WaitFreeRealtimePublisher");
-  }
+  rt_pub.start();
 
   test_msgs::msg::Empty msg;
   for (auto _ : state) {

--- a/realtime_tools/benchmark/realtime_publishers_benchmark.cpp
+++ b/realtime_tools/benchmark/realtime_publishers_benchmark.cpp
@@ -42,6 +42,9 @@ private:
 };
 }  // namespace
 
+////////////////////////////////////////////////////////////////
+// Realtime Publisher Benchmark
+////////////////////////////////////////////////////////////////
 static void BM_RealtimePublisher(benchmark::State & state)
 {
   auto pub = std::make_shared<BenchmarkPublisher<test_msgs::msg::Empty>>();
@@ -57,7 +60,9 @@ static void BM_RealtimePublisher(benchmark::State & state)
 // Register the function as a benchmark
 BENCHMARK(BM_RealtimePublisher);
 
-// Define another benchmark
+////////////////////////////////////////////////////////////////
+// WaitFree Realtime Publisher Parameter Sweep
+////////////////////////////////////////////////////////////////
 template <std::size_t Capacity>
 static void BM_WaitFreeRealtimePublisher(benchmark::State & state)
 {
@@ -88,6 +93,9 @@ BENCHMARK_TEMPLATE(BM_WaitFreeRealtimePublisher, 2)->Apply(MicrosecondSweepArgs)
 BENCHMARK_TEMPLATE(BM_WaitFreeRealtimePublisher, 5)->Apply(MicrosecondSweepArgs);
 BENCHMARK_TEMPLATE(BM_WaitFreeRealtimePublisher, 10)->Apply(MicrosecondSweepArgs);
 
+////////////////////////////////////////////////////////////////
+// Manually Configured  WaitFree Realtime Publisher Benchmark
+////////////////////////////////////////////////////////////////
 static void BM_ManualWaitFreeRealtimePublisher(benchmark::State & state)
 {
   auto pub = std::make_shared<BenchmarkPublisher<test_msgs::msg::Empty>>();

--- a/realtime_tools/benchmark/realtime_publishers_benchmark.cpp
+++ b/realtime_tools/benchmark/realtime_publishers_benchmark.cpp
@@ -70,6 +70,7 @@ static void BM_WaitFreeRealtimePublisher(benchmark::State & state)
   auto pub = std::make_shared<BenchmarkPublisher<test_msgs::msg::Empty>>();
   realtime_tools::WaitFreeRealtimePublisher<test_msgs::msg::Empty, Capacity> rt_pub(
     pub, std::chrono::microseconds(poll_duration_us));
+  rt_pub.start();
 
   test_msgs::msg::Empty msg;
   for (auto _ : state) {
@@ -96,11 +97,11 @@ BENCHMARK_TEMPLATE(BM_WaitFreeRealtimePublisher, 10)->Apply(MicrosecondSweepArgs
 ////////////////////////////////////////////////////////////////
 // Manually Configured WaitFree Realtime Publisher Benchmark
 ////////////////////////////////////////////////////////////////
-static void BM_ManualWaitFreeRealtimePublisher(benchmark::State & state)
+static void BM_DefaultWaitFreeRealtimePublisher(benchmark::State & state)
 {
   auto pub = std::make_shared<BenchmarkPublisher<test_msgs::msg::Empty>>();
-  realtime_tools::WaitFreeRealtimePublisher<test_msgs::msg::Empty, 2> rt_pub(
-    pub, std::chrono::microseconds(1));
+  realtime_tools::WaitFreeRealtimePublisher<test_msgs::msg::Empty> rt_pub(pub);
+  rt_pub.start();
 
   test_msgs::msg::Empty msg;
   for (auto _ : state) {
@@ -110,6 +111,6 @@ static void BM_ManualWaitFreeRealtimePublisher(benchmark::State & state)
   state.counters["num_publishes"] = pub->count();
 }
 
-BENCHMARK(BM_ManualWaitFreeRealtimePublisher);
+BENCHMARK(BM_DefaultWaitFreeRealtimePublisher);
 
 BENCHMARK_MAIN();

--- a/realtime_tools/benchmark/realtime_publishers_benchmark.cpp
+++ b/realtime_tools/benchmark/realtime_publishers_benchmark.cpp
@@ -17,6 +17,7 @@
 #include <benchmark/benchmark.h>
 
 #include <chrono>
+#include <exception>
 #include <memory>
 #include <string>
 #include <vector>
@@ -70,7 +71,9 @@ static void BM_WaitFreeRealtimePublisher(benchmark::State & state)
   auto pub = std::make_shared<BenchmarkPublisher<test_msgs::msg::Empty>>();
   realtime_tools::WaitFreeRealtimePublisher<test_msgs::msg::Empty, Capacity> rt_pub(
     pub, std::chrono::microseconds(poll_duration_us));
-  rt_pub.start();
+  if (!rt_pub.start()) {
+    throw std::runtime_error("Failed to start WaitFreeRealtimePublisher");
+  }
 
   test_msgs::msg::Empty msg;
   for (auto _ : state) {
@@ -101,7 +104,9 @@ static void BM_DefaultWaitFreeRealtimePublisher(benchmark::State & state)
 {
   auto pub = std::make_shared<BenchmarkPublisher<test_msgs::msg::Empty>>();
   realtime_tools::WaitFreeRealtimePublisher<test_msgs::msg::Empty> rt_pub(pub);
-  rt_pub.start();
+  if (!rt_pub.start()) {
+    throw std::runtime_error("Failed to start WaitFreeRealtimePublisher");
+  }
 
   test_msgs::msg::Empty msg;
   for (auto _ : state) {

--- a/realtime_tools/include/realtime_tools/realtime_publisher.hpp
+++ b/realtime_tools/include/realtime_tools/realtime_publisher.hpp
@@ -47,6 +47,7 @@
 #include <utility>
 
 #include "rclcpp/publisher.hpp"
+#include "realtime_tools/utils/publisher_interface.hpp"
 
 namespace realtime_tools
 {
@@ -73,6 +74,11 @@ public:
    * \param publisher the ROS publisher to wrap
    */
   explicit RealtimePublisher(PublisherSharedPtr publisher)
+  : RealtimePublisher(std::make_shared<utils::ROSPublisherWrapper<MessageT>>(publisher))
+  {
+  }
+
+  explicit RealtimePublisher(std::shared_ptr<utils::PublisherInterface<MessageT>> publisher)
   : publisher_(publisher), is_running_(false), keep_running_(true), turn_(State::LOOP_NOT_STARTED)
   {
     thread_ = std::thread(&RealtimePublisher::publishingLoop, this);
@@ -226,7 +232,7 @@ private:
     is_running_ = false;
   }
 
-  PublisherSharedPtr publisher_;
+  std::shared_ptr<utils::PublisherInterface<MessageT>> publisher_;
   std::atomic<bool> is_running_;
   std::atomic<bool> keep_running_;
 

--- a/realtime_tools/include/realtime_tools/utils/publisher_interface.hpp
+++ b/realtime_tools/include/realtime_tools/utils/publisher_interface.hpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2025, Brian Jin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Author: Brian Jin
+
+#ifndef REALTIME_TOOLS__UTILS__PUBLISHER_INTERFACE_HPP_
+#define REALTIME_TOOLS__UTILS__PUBLISHER_INTERFACE_HPP_
+
+#include "rclcpp/publisher.hpp"
+
+namespace realtime_tools::utils
+{
+template <class MessageT>
+class PublisherInterface
+{
+public:
+  virtual void publish(const MessageT & msg) = 0;
+};
+
+template <class MessageT>
+class ROSPublisherWrapper : public PublisherInterface<MessageT>
+{
+public:
+  using PublisherSharedPtr = typename rclcpp::Publisher<MessageT>::SharedPtr;
+  explicit ROSPublisherWrapper(PublisherSharedPtr publisher) : publisher_(publisher) {}
+
+  void publish(const MessageT & msg) override { publisher_->publish(msg); }
+
+private:
+  PublisherSharedPtr publisher_;
+};
+
+}  // namespace realtime_tools::utils
+
+#endif  // REALTIME_TOOLS__UTILS__PUBLISHER_INTERFACE_HPP_

--- a/realtime_tools/include/realtime_tools/wait_free_realtime_publisher.hpp
+++ b/realtime_tools/include/realtime_tools/wait_free_realtime_publisher.hpp
@@ -90,7 +90,7 @@ public:
    */
   explicit WaitFreeRealtimePublisher(
     PublisherSharedPtr publisher,
-    std::chrono::microseconds sleep_poll_duration = std::chrono::microseconds(1))
+    std::chrono::nanoseconds sleep_poll_duration = std::chrono::microseconds(1))
   : WaitFreeRealtimePublisher(
       std::make_shared<utils::ROSPublisherWrapper<MessageT>>(publisher), sleep_poll_duration)
   {
@@ -109,7 +109,7 @@ public:
    */
   explicit WaitFreeRealtimePublisher(
     std::shared_ptr<utils::PublisherInterface<MessageT>> publisher,
-    std::chrono::microseconds sleep_poll_duration = std::chrono::microseconds(1))
+    std::chrono::nanoseconds sleep_poll_duration = std::chrono::microseconds(1))
   : publisher_(publisher), sleep_poll_duration_(sleep_poll_duration)
   {
   }
@@ -322,7 +322,7 @@ private:
   std::atomic<bool> is_running_{false};
 
   /// Duration to sleep when the queue is empty (configurable to balance CPU usage vs latency)
-  const std::chrono::microseconds sleep_poll_duration_;
+  const std::chrono::nanoseconds sleep_poll_duration_;
 
   /// Background thread that handles message publishing
   std::thread thread_;

--- a/realtime_tools/include/realtime_tools/wait_free_realtime_publisher.hpp
+++ b/realtime_tools/include/realtime_tools/wait_free_realtime_publisher.hpp
@@ -56,10 +56,14 @@ public:
     }
   }
 
+  ~WaitFreeRealtimePublisher() { stop(); }
+
   void stop()
   {
     is_running_ = false;
-    thread_.join();
+    if (thread_.joinable()) {
+      thread_.join();
+    }
   }
 
   void start()

--- a/realtime_tools/include/realtime_tools/wait_free_realtime_publisher.hpp
+++ b/realtime_tools/include/realtime_tools/wait_free_realtime_publisher.hpp
@@ -1,0 +1,116 @@
+// Copyright (c) 2025, Brian Jin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Author: Brian Jin
+
+#ifndef REALTIME_TOOLS__WAIT_FREE_REALTIME_PUBLISHER_HPP_
+#define REALTIME_TOOLS__WAIT_FREE_REALTIME_PUBLISHER_HPP_
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+
+#include "rclcpp/publisher.hpp"
+#include "realtime_tools/lock_free_queue.hpp"
+
+namespace realtime_tools
+{
+
+template <class MessageT>
+class PublisherInterface
+{
+public:
+  virtual void publish(const MessageT & msg) = 0;
+};
+
+template <class MessageT, std::size_t Capacity = 1>
+class WaitFreeRealtimePublisher
+{
+public:
+  using PublisherSharedPtr = typename rclcpp::Publisher<MessageT>::SharedPtr;
+
+  explicit WaitFreeRealtimePublisher(PublisherSharedPtr publisher)
+  : WaitFreeRealtimePublisher(std::make_unique<ROSPublisherWrapper>(publisher))
+  {
+  }
+
+  explicit WaitFreeRealtimePublisher(std::shared_ptr<PublisherInterface<MessageT>> publisher)
+  : publisher_(publisher), is_running_(true)
+  {
+    thread_ = std::thread(&WaitFreeRealtimePublisher::publishingLoop, this);
+
+    while (!thread_.joinable()) {
+      std::this_thread::sleep_for(std::chrono::microseconds(100));
+    }
+  }
+
+  void stop()
+  {
+    is_running_ = false;
+    thread_.join();
+  }
+
+  void start()
+  {
+    if (!thread_.joinable()) {
+      is_running_ = true;
+      thread_ = std::thread(&WaitFreeRealtimePublisher::publishingLoop, this);
+    }
+  }
+
+  bool push(const MessageT & msg) { return message_queue_.push(msg); }
+
+private:
+  class ROSPublisherWrapper : public PublisherInterface<MessageT>
+  {
+  public:
+    explicit ROSPublisherWrapper(PublisherSharedPtr publisher) : publisher_(publisher) {}
+
+    void publish(const MessageT & msg) override { publisher_->publish(msg); }
+
+  private:
+    PublisherSharedPtr publisher_;
+  };
+
+  void publishingLoop()
+  {
+    while (is_running_) {
+      MessageT outgoing;
+
+      if (message_queue_.empty()) {
+        // No message to publish, sleep briefly to avoid busy-waiting
+        std::this_thread::sleep_for(std::chrono::microseconds(10));
+        continue;
+      }
+
+      if (!message_queue_.pop(outgoing)) {
+        // Failed to pop message, continue to next iteration
+        continue;
+      }
+
+      // Sends the outgoing message
+      publisher_->publish(outgoing);
+    }
+  }
+
+  LockFreeSPSCQueue<MessageT, Capacity> message_queue_;
+  std::shared_ptr<PublisherInterface<MessageT>> publisher_;
+
+  std::thread thread_;
+  std::atomic<bool> is_running_;
+};
+
+}  // namespace realtime_tools
+#endif  // REALTIME_TOOLS__WAIT_FREE_REALTIME_PUBLISHER_HPP_

--- a/realtime_tools/include/realtime_tools/wait_free_realtime_publisher.hpp
+++ b/realtime_tools/include/realtime_tools/wait_free_realtime_publisher.hpp
@@ -42,7 +42,7 @@ public:
   using PublisherSharedPtr = typename rclcpp::Publisher<MessageT>::SharedPtr;
 
   explicit WaitFreeRealtimePublisher(PublisherSharedPtr publisher)
-  : WaitFreeRealtimePublisher(std::make_unique<ROSPublisherWrapper>(publisher))
+  : WaitFreeRealtimePublisher(publisher)
   {
   }
 
@@ -71,6 +71,8 @@ public:
   }
 
   bool push(const MessageT & msg) { return message_queue_.push(msg); }
+
+  bool running() const { return is_running_; }
 
 private:
   class ROSPublisherWrapper : public PublisherInterface<MessageT>

--- a/realtime_tools/include/realtime_tools/wait_free_realtime_publisher.hpp
+++ b/realtime_tools/include/realtime_tools/wait_free_realtime_publisher.hpp
@@ -54,6 +54,9 @@ class WaitFreeRealtimePublisher
  * The publisher uses a polling mechanism with configurable sleep duration to check
  * for new messages in the queue, balancing CPU usage with publishing latency.
  *
+ * Default settings are derived from benchmarks, and are selected to balance low latency
+ * while still having high publish rates. Use benchmarks to find your optimal settings.
+ *
  * @tparam MessageT The ROS message type to publish
  * @tparam Capacity The maximum number of messages that can be queued (default: 2)
  *

--- a/realtime_tools/include/realtime_tools/wait_free_realtime_publisher.hpp
+++ b/realtime_tools/include/realtime_tools/wait_free_realtime_publisher.hpp
@@ -36,7 +36,7 @@ public:
   using PublisherSharedPtr = typename rclcpp::Publisher<MessageT>::SharedPtr;
 
   explicit WaitFreeRealtimePublisher(PublisherSharedPtr publisher)
-  : WaitFreeRealtimePublisher(publisher)
+  : WaitFreeRealtimePublisher(std::make_shared<utils::ROSPublisherWrapper<MessageT>>(publisher))
   {
   }
 

--- a/realtime_tools/package.xml
+++ b/realtime_tools/package.xml
@@ -21,6 +21,7 @@
 
   <build_depend>ros2_control_cmake</build_depend>
 
+  <depend>google_benchmark_vendor</depend>
   <depend>libboost-dev</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_action</depend>

--- a/realtime_tools/test/wait_free_publisher_test.cpp
+++ b/realtime_tools/test/wait_free_publisher_test.cpp
@@ -22,9 +22,10 @@
 #include <mutex>
 #include <test_msgs/msg/empty.hpp>
 
+#include <realtime_tools/utils/publisher_interface.hpp>
 #include <realtime_tools/wait_free_realtime_publisher.hpp>
 
-class MockPublisher : public realtime_tools::PublisherInterface<test_msgs::msg::Empty>
+class MockPublisher : public realtime_tools::utils::PublisherInterface<test_msgs::msg::Empty>
 {
 public:
   MOCK_METHOD(void, publish, (const test_msgs::msg::Empty & msg), (override));

--- a/realtime_tools/test/wait_free_publisher_test.cpp
+++ b/realtime_tools/test/wait_free_publisher_test.cpp
@@ -65,7 +65,7 @@ TEST_P(PublishTest, PushAndPublish)
     }));
 
   realtime_tools::WaitFreeRealtimePublisher<test_msgs::msg::Empty, 1> rt_pub(mock_publisher_ptr);
-  ASSERT_TRUE(rt_pub.start());
+  rt_pub.start();
 
   for (int i = 0; i < expected_publish_calls; ++i) {
     ASSERT_TRUE(rt_pub.push(msg));
@@ -112,7 +112,7 @@ TEST(WaitFreeRealtimePublisherTests, PushCapacity)
 
   realtime_tools::WaitFreeRealtimePublisher<test_msgs::msg::Empty, kExpectedPublishCalls> rt_pub(
     mock_publisher_ptr);
-  ASSERT_TRUE(rt_pub.start());
+  rt_pub.start();
 
   for (int i = 0; i < kExpectedPublishCalls; ++i) {
     ASSERT_TRUE(rt_pub.push(msg));
@@ -151,11 +151,11 @@ TEST(WaitFreeRealtimePublisherTests, Start)
   realtime_tools::WaitFreeRealtimePublisher<test_msgs::msg::Empty> rt_pub(mock_publisher_ptr);
 
   // Call once
-  ASSERT_TRUE(rt_pub.start());
+  rt_pub.start();
   EXPECT_TRUE(rt_pub.running());
 
   // Subsequent calls should have no effect
-  ASSERT_TRUE(rt_pub.start());
+  rt_pub.start();
   EXPECT_TRUE(rt_pub.running());
 }
 
@@ -170,7 +170,7 @@ TEST(DISABLED_WaitFreeRealtimePublisherTests, RealtimeStart)
   std::vector<int> cpu_affinity = {0};
 
   // Call once
-  ASSERT_TRUE(rt_pub.start(thread_priority, cpu_affinity));
+  rt_pub.start(thread_priority, cpu_affinity);
 }
 #endif
 
@@ -184,7 +184,7 @@ TEST(WaitFreeRealtimePublisherTests, Stop)
   EXPECT_FALSE(rt_pub.running());
 
   // Call once
-  ASSERT_TRUE(rt_pub.start());
+  rt_pub.start();
 
   // Regular stop should also be ok
   rt_pub.stop();
@@ -204,7 +204,7 @@ TEST(WaitFreeRealtimePublisherTests, ROSPublisher)
   auto pub = node->create_publisher<test_msgs::msg::Empty>("~/rt_publish", qos);
   realtime_tools::WaitFreeRealtimePublisher<test_msgs::msg::Empty> rt_pub(pub);
 
-  ASSERT_TRUE(rt_pub.start());
+  rt_pub.start();
   EXPECT_TRUE(rt_pub.running());
 
   rclcpp::shutdown();

--- a/realtime_tools/test/wait_free_publisher_test.cpp
+++ b/realtime_tools/test/wait_free_publisher_test.cpp
@@ -29,7 +29,7 @@ public:
   MOCK_METHOD(void, publish, (const test_msgs::msg::Empty & msg), (override));
 };
 
-TEST(WaitFreeRealtimePublisherTests, push_and_publish)
+TEST(WaitFreeRealtimePublisherTests, PushAndPublish)
 {
   auto mock_publisher_ptr = std::make_shared<MockPublisher>();
   test_msgs::msg::Empty msg;
@@ -58,4 +58,55 @@ TEST(WaitFreeRealtimePublisherTests, push_and_publish)
   }
 
   rt_pub.stop();
+}
+
+TEST(WaitFreeRealtimePublisherTests, Constructor)
+{
+  auto mock_publisher_ptr = std::make_shared<MockPublisher>();
+  realtime_tools::WaitFreeRealtimePublisher<test_msgs::msg::Empty> rt_pub(mock_publisher_ptr);
+
+  // Should be running after construction
+  EXPECT_TRUE(rt_pub.running());
+}
+
+TEST(WaitFreeRealtimePublisherTests, Destructor)
+{
+  auto mock_publisher_ptr = std::make_shared<MockPublisher>();
+  realtime_tools::WaitFreeRealtimePublisher<test_msgs::msg::Empty> rt_pub(mock_publisher_ptr);
+  // Should destruct without blocking
+}
+
+TEST(WaitFreeRealtimePublisherTests, Start)
+{
+  auto mock_publisher_ptr = std::make_shared<MockPublisher>();
+  realtime_tools::WaitFreeRealtimePublisher<test_msgs::msg::Empty> rt_pub(mock_publisher_ptr);
+
+  // Call once
+  rt_pub.start();
+  EXPECT_TRUE(rt_pub.running());
+
+  // Subsequent calls should have no effect
+  rt_pub.start();
+  EXPECT_TRUE(rt_pub.running());
+}
+
+TEST(WaitFreeRealtimePublisherTests, Stop)
+{
+  auto mock_publisher_ptr = std::make_shared<MockPublisher>();
+  realtime_tools::WaitFreeRealtimePublisher<test_msgs::msg::Empty> rt_pub(mock_publisher_ptr);
+
+  // Empty call should be ok
+  rt_pub.stop();
+  EXPECT_FALSE(rt_pub.running());
+
+  // Call once
+  rt_pub.start();
+
+  // Regular stop should also be ok
+  rt_pub.stop();
+  EXPECT_FALSE(rt_pub.running());
+
+  // Subsequent calls should have no effect
+  rt_pub.stop();
+  EXPECT_FALSE(rt_pub.running());
 }

--- a/realtime_tools/test/wait_free_publisher_test.cpp
+++ b/realtime_tools/test/wait_free_publisher_test.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2025, Brian Jin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Author: Brian Jin
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <memory>
+#include <test_msgs/msg/empty.hpp>
+
+#include <realtime_tools/wait_free_realtime_publisher.hpp>
+
+class MockPublisher : public realtime_tools::PublisherInterface<test_msgs::msg::Empty>
+{
+public:
+  MOCK_METHOD(void, publish, (const test_msgs::msg::Empty & msg), (override));
+};
+
+TEST(WaitFreeRealtimePublisherTests, push_and_publish)
+{
+  auto mock_publisher = std::make_shared<MockPublisher>();
+
+  realtime_tools::WaitFreeRealtimePublisher<test_msgs::msg::Empty> rt_pub(mock_publisher);
+
+  test_msgs::msg::Empty msg;
+
+  ASSERT_TRUE(rt_pub.push(msg));
+
+  EXPECT_CALL(*mock_publisher, publish(testing::Eq(msg))).Times(1);
+
+  // Give some time for the publishing thread to process the message
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+
+  rt_pub.stop();
+}

--- a/realtime_tools/test/wait_free_publisher_test.cpp
+++ b/realtime_tools/test/wait_free_publisher_test.cpp
@@ -61,7 +61,8 @@ TEST_P(PublishTest, PushAndPublish)
       publish_cv.notify_one();
     }));
 
-  realtime_tools::WaitFreeRealtimePublisher<test_msgs::msg::Empty> rt_pub(mock_publisher_ptr);
+  realtime_tools::WaitFreeRealtimePublisher<test_msgs::msg::Empty, 1> rt_pub(mock_publisher_ptr);
+  rt_pub.start();
 
   for (int i = 0; i < expected_publish_calls; ++i) {
     ASSERT_TRUE(rt_pub.push(msg));
@@ -108,6 +109,7 @@ TEST(WaitFreeRealtimePublisherTests, PushCapacity)
 
   realtime_tools::WaitFreeRealtimePublisher<test_msgs::msg::Empty, kExpectedPublishCalls> rt_pub(
     mock_publisher_ptr);
+  rt_pub.start();
 
   for (int i = 0; i < kExpectedPublishCalls; ++i) {
     ASSERT_TRUE(rt_pub.push(msg));
@@ -129,7 +131,8 @@ TEST(WaitFreeRealtimePublisherTests, Constructor)
   auto mock_publisher_ptr = std::make_shared<MockPublisher>();
   realtime_tools::WaitFreeRealtimePublisher<test_msgs::msg::Empty> rt_pub(mock_publisher_ptr);
 
-  // Should be running after construction  EXPECT_TRUE(rt_pub.running());
+  // Should not be running after construction
+  EXPECT_FALSE(rt_pub.running());
 }
 
 TEST(WaitFreeRealtimePublisherTests, Destructor)

--- a/realtime_tools/test/wait_free_publisher_test.cpp
+++ b/realtime_tools/test/wait_free_publisher_test.cpp
@@ -22,6 +22,8 @@
 #include <mutex>
 #include <test_msgs/msg/empty.hpp>
 
+#include "rclcpp/node.hpp"
+
 #include <realtime_tools/utils/publisher_interface.hpp>
 #include <realtime_tools/wait_free_realtime_publisher.hpp>
 
@@ -170,4 +172,19 @@ TEST(WaitFreeRealtimePublisherTests, Stop)
   // Subsequent calls should have no effect
   rt_pub.stop();
   EXPECT_FALSE(rt_pub.running());
+}
+
+TEST(WaitFreeRealtimePublisherTests, ROSPublisher)
+{
+  rclcpp::init(0, nullptr);
+  auto node = std::make_shared<rclcpp::Node>("construct_move_destruct");
+  rclcpp::QoS qos(10);
+  qos.reliable().transient_local();
+  auto pub = node->create_publisher<test_msgs::msg::Empty>("~/rt_publish", qos);
+  realtime_tools::WaitFreeRealtimePublisher<test_msgs::msg::Empty> rt_pub(pub);
+
+  rt_pub.start();
+  EXPECT_TRUE(rt_pub.running());
+
+  rclcpp::shutdown();
 }

--- a/realtime_tools/test/wait_free_publisher_test.test
+++ b/realtime_tools/test/wait_free_publisher_test.test
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+  <test test-name="wait_free_publisher_test" pkg="realtime_tools" type="wait_free_publisher_test" />
+</launch>


### PR DESCRIPTION
# Background

`RealtimePublisher` class uses locking mechanisms to publish data in a separate thread, but given it follows a single-producer single-consumer paradigm, we can create a wait-free implementation using the `LockFreeQueue` data structure in this repo. This PR is an attempt to introduce this implementation.

# Changes

- Adds a `WaitFreeRealtimePublisher` class, which compared to `RealtimePublisher`:
  - similarities:
    - spawns a separate thread for publishing messages
  - differences:
    - wait-free
    - background thread has configurable priority and CPU affinity (Linux only)
    - does not spawn publishing thread on construction
    - slightly different public API
- Introduces a benchmark script to compare `WaitFreeRealtimePublisher` to `RealtimePublisher`
  - consequently slightly changes `RealtimePublisher` to support benchmarking, and also adds publisher interface abstraction for benchmarks and test

# Testing

- unit tests
- benchmark

## Benchmark Results

Settings:
- linux machine with isolated cores 0,1. Publishing thread is pinned to core 1 while main thread is core 0
- disabled cpu scaling
- compiled with release mode

Example Results: wait-free publishing side is 2 orders of magnitude faster than `RealtimePublisher` on the producer-side. I'm still a bit confused by the publishing thread side: the other day I was also seeing an order of magnitude of messages that were published, so maybe this benchmark needs some tuning.
```
Running ./build/realtime_tools/realtime_publishers_benchmark
Run on (12 X 400 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 1280 KiB (x6)
  L3 Unified 12288 KiB (x1)
Load Average: 0.62, 0.55, 0.60
----------------------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------------------------
BM_RealtimePublisher                      26.9 ns         17.0 ns     41174747 num_publishes=484.333k
BM_WaitFreeRealtimePublisher<1>/1        0.398 ns        0.398 ns   1000000000 num_publishes=7.508k
BM_WaitFreeRealtimePublisher<1>/5        0.397 ns        0.397 ns   1000000000 num_publishes=6.984k
BM_WaitFreeRealtimePublisher<1>/10       0.398 ns        0.398 ns   1000000000 num_publishes=6.399k
BM_WaitFreeRealtimePublisher<1>/50       0.396 ns        0.396 ns   1000000000 num_publishes=3.866k
BM_WaitFreeRealtimePublisher<2>/1        0.340 ns        0.340 ns   1000000000 num_publishes=12.859k
BM_WaitFreeRealtimePublisher<2>/5        0.340 ns        0.340 ns   1000000000 num_publishes=11.842k
BM_WaitFreeRealtimePublisher<2>/10       0.339 ns        0.339 ns   1000000000 num_publishes=10.871k
BM_WaitFreeRealtimePublisher<2>/50       0.337 ns        0.337 ns   1000000000 num_publishes=6.621k
BM_WaitFreeRealtimePublisher<5>/1        0.314 ns        0.314 ns   1000000000 num_publishes=37.859k
BM_WaitFreeRealtimePublisher<5>/5        0.313 ns        0.313 ns   1000000000 num_publishes=36.552k
BM_WaitFreeRealtimePublisher<5>/10       0.313 ns        0.313 ns   1000000000 num_publishes=33.087k
BM_WaitFreeRealtimePublisher<5>/50       0.312 ns        0.312 ns   1000000000 num_publishes=19.569k
BM_DefaultWaitFreeRealtimePublisher      0.340 ns        0.340 ns   1000000000 num_publishes=12.854k
```
# Notes

- I'm not super familiar with copyright side, so just copy and pasted the same licensing as some other files in this repo. 
