### PR TITLE
Readd migration notes after removal

### DIFF
--- a/doc/migration.rst
+++ b/doc/migration.rst
@@ -4,3 +4,9 @@ Migration Guides: Kilted Kaiju to Lyrical Luth
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This list summarizes important changes between Kilted Kaiju (previous) and Lyrical Luth (current) releases, where changes to user code might be necessary.
+
+RealtimeBox
+*******************************
+* ``RealtimePublisher`` is updated with a new ``try_publish`` API.
+  * Update your code with a local message variable and call ``try_publish`` with that variable. (`#323 <https://github.com/ros-controls/realtime_tools/pull/323>`__).
+  * ``msg_`` variable is inaccessible now (`#421 <https://github.com/ros-controls/realtime_tools/pull/421>`__).


### PR DESCRIPTION
They were added with the deprecation, but after branching for kilted they are not there anymore when we actually removed it.