### PR TITLE
Test downstream packages in downstream CI job

### DIFF
--- a/.github/workflows/humble-binary-downstream-build.yml
+++ b/.github/workflows/humble-binary-downstream-build.yml
@@ -33,4 +33,4 @@ jobs:
       ref_for_scheduled_build: humble
       not_test_build: true
       downstream_workspace: ros_controls.humble.repos
-      not_test_downstream: true
+      not_test_downstream: false

--- a/.github/workflows/jazzy-binary-downstream-build.yml
+++ b/.github/workflows/jazzy-binary-downstream-build.yml
@@ -33,4 +33,4 @@ jobs:
       ref_for_scheduled_build: jazzy
       not_test_build: true
       downstream_workspace: ros_controls.jazzy.repos
-      not_test_downstream: true
+      not_test_downstream: false

--- a/.github/workflows/kilted-binary-downstream-build.yml
+++ b/.github/workflows/kilted-binary-downstream-build.yml
@@ -33,4 +33,4 @@ jobs:
       ref_for_scheduled_build: kilted
       not_test_build: true
       downstream_workspace: ros_controls.kilted.repos
-      not_test_downstream: true
+      not_test_downstream: false

--- a/.github/workflows/rolling-binary-downstream-build.yml
+++ b/.github/workflows/rolling-binary-downstream-build.yml
@@ -37,4 +37,4 @@ jobs:
       ref_for_scheduled_build: master
       not_test_build: true
       downstream_workspace: ros_controls.${{ matrix.ROS_DISTRO }}.repos
-      not_test_downstream: true
+      not_test_downstream: false


### PR DESCRIPTION
#486 introduced an issue in ros2_controllers tests, let's not only build but test downstream packages.