### PR TITLE
Fix CMP0167 and remove FindBoost

### DIFF
--- a/realtime_tools/CMakeLists.txt
+++ b/realtime_tools/CMakeLists.txt
@@ -30,9 +30,8 @@ endforeach()
 
 if(POLICY CMP0167)
   cmake_policy(SET CMP0167 NEW)
-endif()
-find_package(Boost COMPONENTS headers)
-if(NOT Boost_headers_FOUND)
+  find_package(Boost REQUIRED CONFIG)
+else()
   find_package(Boost REQUIRED)
 endif()
 


### PR DESCRIPTION
## Description
on Resolute Racoon we see
```
CMake Warning (dev) at /opt/ros/rolling/share/realtime_tools/cmake/ament_cmake_export_dependencies-extras.cmake:21 (find_package):
  Policy CMP0167 is not set: The FindBoost module is removed.  Run "cmake
  --help-policy CMP0167" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

```
### Is this user-facing behavior change?
no

### Did you use Generative AI?
no