### PR TITLE
Apply CMP0167 also for exported dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,7 +106,7 @@ repos:
         description: Check if copyright notice is available in all files.
         entry: ament_copyright
         language: system
-        exclude: doc/conf.py
+        exclude: doc/conf.py|\.cmake
 
   # Docs - RestructuredText hooks
   - repo: https://github.com/PyCQA/doc8

--- a/realtime_tools/CMakeLists.txt
+++ b/realtime_tools/CMakeLists.txt
@@ -119,5 +119,5 @@ install(TARGETS realtime_tools thread_priority
 )
 
 ament_export_targets(export_realtime_tools HAS_LIBRARY_TARGET)
-ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
-ament_package()
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
+ament_package(CONFIG_EXTRAS cmake/realtime_tools-extras.cmake)

--- a/realtime_tools/cmake/realtime_tools-extras.cmake
+++ b/realtime_tools/cmake/realtime_tools-extras.cmake
@@ -1,0 +1,6 @@
+if(POLICY CMP0167)
+  cmake_policy(SET CMP0167 NEW)
+  find_package(Boost REQUIRED CONFIG)
+else()
+  find_package(Boost REQUIRED)
+endif()


### PR DESCRIPTION
<!--
Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.
5. If a PR is merged all commits will get squashed, a linear commit history is not required.
6. Once a PR got reviewed, please don't do force pushes as this will break github UI and subsequent reviews will take more time.
-->

## Description

#531 fixed CMP0167 for this package, but from `ament_export_dependencies` we still get warnings for downstream packages
```
Starting >>> control_toolbox
--- stderr: control_toolbox                             
CMake Warning (dev) at /workspaces/ros2_rolling_ws/install/realtime_tools/share/realtime_tools/cmake/ament_cmake_export_dependencies-extras.cmake:21 (find_package):
  Policy CMP0167 is not set: The FindBoost module is removed.  Run "cmake
  --help-policy CMP0167" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

Call Stack (most recent call first):
  /workspaces/ros2_rolling_ws/install/realtime_tools/share/realtime_tools/cmake/realtime_toolsConfig.cmake:41 (include)
  CMakeLists.txt:31 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.

---
Finished <<< control_toolbox [2.53s]
```

### Is this user-facing behavior change?
No

### Did you use Generative AI?
GPT-5.3-Codex

### Additional Information
