### PR TITLE
package.xml: correct license to a valid SPDX

### DIFF
--- a/realtime_tools/package.xml
+++ b/realtime_tools/package.xml
@@ -6,7 +6,7 @@
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
   <maintainer email="denis@stoglrobotics.de">Denis Štogl</maintainer>
 
-  <license>3-Clause BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">https://control.ros.org</url>
   <url type="bugtracker">https://github.com/ros-controls/realtime_tools/issues</url>


### PR DESCRIPTION
This was causing a warning in Yocto/OpenEmbedded