### PR TITLE
declare missing Async parameters

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -4,3 +4,6 @@ Release Notes: Kilted Kaiju to Lyrical Luth
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This list summarizes important changes between Kilted Kaiju (previous) and Lyrical Luth (current) releases.
+
+- Added a static ``AsyncFunctionHandlerParams::declare()`` method to declare required ROS 2 node parameters. This moves the parameter definition within ``realtime_tools`` and simplifies node initialization in, for example ros2 controllers.
+- For AsyncParams, ``exec_rate`` parameter is now read from ``update_rate`` parameter of the controller ``.yaml`` config. If not set, controller_manager update rate is used for async component update rate.

--- a/realtime_tools/include/realtime_tools/async_function_handler.hpp
+++ b/realtime_tools/include/realtime_tools/async_function_handler.hpp
@@ -169,24 +169,12 @@ struct AsyncFunctionHandlerParams
   }
 
   /**
-   * @brief Declare the parameters from a node.
-   * The node should have the following parameters:
-   * - thread_priority (int): Priority of the async worker thread. Default is 50.
-   * - cpu_affinity (int[]): CPU cores to which the async worker thread should be pinned.
-   *   Default is empty, which means the thread will not be pinned to any CPU core.
-   * - scheduling_policy (string): Scheduling policy for the async worker thread. Can be either
-   *   "synchronized" or "detached". Default is "synchronized".
-   * - execution_rate (int): Execution rate of the async worker thread in Hz.
-   * - wait_until_initial_trigger (bool): Whether to wait until the initial trigger predicate is true
-   *   before starting the async callback method. Default is true.
-   * - print_warnings (bool): Whether to print warnings when the async callback method is not triggered
-   *   due to any reason. Default is true.
-   * - thread_name (string): Name applied to the async thread. Defaults to component name. Truncated to 15 chars.
-   * @param node The node that is used to declare the parameters.
-   * @param prefix Parameter prefix to use when declaring node parameters.
+   * @brief Declares and initialize the parameters from a node's parameters.
+   * @param node The node that is used to get the parameters.
+   * @param prefix Parameter prefix to use when accessing node parameters.
    */
   template <typename NodeT>
-  static void declare(NodeT & node, const std::string & prefix)
+  void initialize(NodeT & node, const std::string & prefix)
   {
     if (!node->has_parameter(prefix + "thread_priority")) {
       node->template declare_parameter<int>(prefix + "thread_priority", 50);
@@ -207,16 +195,7 @@ struct AsyncFunctionHandlerParams
     if (!node->has_parameter(prefix + "thread_name")) {
       node->template declare_parameter<std::string>(prefix + "thread_name", "");
     }
-  }
 
-  /**
-   * @brief Initialize the parameters from a node's parameters.
-   * @param node The node that is used to get the parameters.
-   * @param prefix Parameter prefix to use when accessing node parameters.
-   */
-  template <typename NodeT>
-  void initialize(NodeT & node, const std::string & prefix)
-  {
     if (node->has_parameter(prefix + "thread_priority")) {
       thread_priority = static_cast<int>(node->get_parameter(prefix + "thread_priority").as_int());
     }

--- a/realtime_tools/include/realtime_tools/async_function_handler.hpp
+++ b/realtime_tools/include/realtime_tools/async_function_handler.hpp
@@ -167,7 +167,7 @@ struct AsyncFunctionHandlerParams
   }
 
   /**
-   * @brief Initialize the parameters from a node's parameters.
+   * @brief Declare the parameters from a node.
    * The node should have the following parameters:
    * - thread_priority (int): Priority of the async worker thread. Default is 50.
    * - cpu_affinity (int[]): CPU cores to which the async worker thread should be pinned.
@@ -180,6 +180,39 @@ struct AsyncFunctionHandlerParams
    * - print_warnings (bool): Whether to print warnings when the async callback method is not triggered
    *   due to any reason. Default is true.
    * - thread_name (string): Name applied to the async thread. Defaults to component name. Truncated to 15 chars.
+   * @param node The node that is used to declare the parameters.
+   * @param prefix Parameter prefix to use when declaring node parameters.
+   * @param default_exec_rate The fallback execution rate to declare (usually the controller's update_rate).
+   */
+  template <typename NodeT>
+  static void declare(NodeT & node, const std::string & prefix, int default_exec_rate = 0)
+  {
+    if (!node->has_parameter(prefix + "thread_priority")) {
+      node->template declare_parameter<int>(prefix + "thread_priority", 50);
+    }
+    if (!node->has_parameter(prefix + "cpu_affinity")) {
+      node->template declare_parameter<std::vector<int64_t>>(
+        prefix + "cpu_affinity", std::vector<int64_t>());
+    }
+    if (!node->has_parameter(prefix + "scheduling_policy")) {
+      node->template declare_parameter<std::string>(prefix + "scheduling_policy", "synchronized");
+    }
+    if (!node->has_parameter(prefix + "execution_rate")) {
+      node->template declare_parameter<int>(prefix + "execution_rate", default_exec_rate);
+    }
+    if (!node->has_parameter(prefix + "wait_until_initial_trigger")) {
+      node->template declare_parameter<bool>(prefix + "wait_until_initial_trigger", true);
+    }
+    if (!node->has_parameter(prefix + "print_warnings")) {
+      node->template declare_parameter<bool>(prefix + "print_warnings", true);
+    }
+    if (!node->has_parameter(prefix + "thread_name")) {
+      node->template declare_parameter<std::string>(prefix + "thread_name", "");
+    }
+  }
+
+  /**
+   * @brief Initialize the parameters from a node's parameters.
    * @param node The node that is used to get the parameters.
    * @param prefix Parameter prefix to use when accessing node parameters.
    */

--- a/realtime_tools/include/realtime_tools/async_function_handler.hpp
+++ b/realtime_tools/include/realtime_tools/async_function_handler.hpp
@@ -182,10 +182,9 @@ struct AsyncFunctionHandlerParams
    * - thread_name (string): Name applied to the async thread. Defaults to component name. Truncated to 15 chars.
    * @param node The node that is used to declare the parameters.
    * @param prefix Parameter prefix to use when declaring node parameters.
-   * @param default_exec_rate The fallback execution rate to declare (usually the controller's update_rate).
    */
   template <typename NodeT>
-  static void declare(NodeT & node, const std::string & prefix, int default_exec_rate = 0)
+  static void declare(NodeT & node, const std::string & prefix)
   {
     if (!node->has_parameter(prefix + "thread_priority")) {
       node->template declare_parameter<int>(prefix + "thread_priority", 50);
@@ -196,9 +195,6 @@ struct AsyncFunctionHandlerParams
     }
     if (!node->has_parameter(prefix + "scheduling_policy")) {
       node->template declare_parameter<std::string>(prefix + "scheduling_policy", "synchronized");
-    }
-    if (!node->has_parameter(prefix + "execution_rate")) {
-      node->template declare_parameter<int>(prefix + "execution_rate", default_exec_rate);
     }
     if (!node->has_parameter(prefix + "wait_until_initial_trigger")) {
       node->template declare_parameter<bool>(prefix + "wait_until_initial_trigger", true);
@@ -232,17 +228,6 @@ struct AsyncFunctionHandlerParams
     if (node->has_parameter(prefix + "scheduling_policy")) {
       scheduling_policy =
         AsyncSchedulingPolicy(node->get_parameter(prefix + "scheduling_policy").as_string());
-    }
-    if (
-      scheduling_policy == AsyncSchedulingPolicy::DETACHED &&
-      node->has_parameter(prefix + "execution_rate")) {
-      const int execution_rate =
-        static_cast<int>(node->get_parameter(prefix + "execution_rate").as_int());
-      if (execution_rate <= 0) {
-        throw std::runtime_error(
-          "AsyncFunctionHandler: execution_rate parameter must be positive.");
-      }
-      exec_rate = static_cast<unsigned int>(execution_rate);
     }
     if (node->has_parameter(prefix + "wait_until_initial_trigger")) {
       wait_until_initial_trigger =


### PR DESCRIPTION
Based on [this comment,](https://github.com/ros-controls/ros2_control/pull/3481#discussion_r3615645563) moved declaration of parameters out of `controller_interface_base.cpp` into `async_function_handler`

Needs https://github.com/ros-controls/ros2_control/pull/3481 merged. Basis for this PR for renaming threads for async hw: https://github.com/ros-controls/ros2_control/pull/3482

### To sum up, this is the merging order:
1. This MR, to declare the parameters
2. https://github.com/ros-controls/ros2_control/pull/3481, to call the declaration function from `controller_interface_base.cpp`
3. finally, https://github.com/ros-controls/ros2_control/pull/3482, to parameterize renaming of threads

### Nice to have, on this topic:
Printing CPU cores we pin threads on PR: https://github.com/ros-controls/realtime_tools/pull/551