### PR TITLE
refactor: deprecate RealtimeBuffer and its headerfile

### DIFF
--- a/realtime_tools/include/realtime_tools/realtime_buffer.hpp
+++ b/realtime_tools/include/realtime_tools/realtime_buffer.hpp
@@ -37,10 +37,19 @@
 #include <mutex>
 #include <thread>
 
+#ifndef SILENCE_DEPRECATION_WARNINGS
+#ifdef _MSC_VER
+#pragma message( \
+  "This header is obsolete, please use \"realtime_tools/realtime_thread_safe_box.hpp\" instead.")
+#else
+#warning This header is obsolete, please use "realtime_tools/realtime_thread_safe_box.hpp" instead.
+#endif
+#endif
+
 namespace realtime_tools
 {
 template <class T>
-class RealtimeBuffer
+class [[deprecated("Use realtime_tools::RealtimeThreadSafeBox instead.")]] RealtimeBuffer
 {
 public:
   RealtimeBuffer() : new_data_available_(false)

--- a/realtime_tools/include/realtime_tools/realtime_buffer.hpp
+++ b/realtime_tools/include/realtime_tools/realtime_buffer.hpp
@@ -39,17 +39,21 @@
 
 #ifndef SILENCE_DEPRECATION_WARNINGS
 #ifdef _MSC_VER
-#pragma message( \
-  "This header is obsolete, please use \"realtime_tools/realtime_thread_safe_box.hpp\" instead.")
+#pragma message(                                                                      \
+  "This header is obsolete, please refer to the guidelines for replacement options: " \
+  "control.ros.org/rolling/doc/realtime_tools/doc/index.html#guidelines")
 #else
-#warning This header is obsolete, please use "realtime_tools/realtime_thread_safe_box.hpp" instead.
+#warning This header is obsolete, please refer to the guidelines for replacement options: \
+control.ros.org/rolling/doc/realtime_tools/doc/index.html#guidelines
 #endif
 #endif
 
 namespace realtime_tools
 {
 template <class T>
-class [[deprecated("Use realtime_tools::RealtimeThreadSafeBox instead.")]] RealtimeBuffer
+class [[deprecated(
+  "refer to the guidelines for replacement options: "
+  "control.ros.org/rolling/doc/realtime_tools/doc/index.html#guidelines")]] RealtimeBuffer
 {
 public:
   RealtimeBuffer() : new_data_available_(false)


### PR DESCRIPTION
## Description

This PR deprecates the old `RealtimeBuffer` class and its header file `realtime_buffer.hpp` in favor of the modern `RealtimeThreadSafeBox` API.

Specifically, it completes the following:
1. Deprecates the `RealtimeBuffer` class itself using the C++14 standard `[[deprecated]]` attribute.
2. Deprecates the `realtime_buffer.hpp` header file by introducing compiler warning diagnostics (`#warning` for GCC/Clang and `#pragma message` for MSVC), which can be silenced by defining the `SILENCE_DEPRECATION_WARNINGS` macro.

## Is this user-facing behavior change?

No

## Did you use Generative AI?

No

## Additional Information

Verified locally that the pre-commit checks run and pass successfully:

```bash
pre-commit run --files realtime_tools/include/realtime_tools/realtime_buffer.hpp