### PR TITLE
feat: create publisher internally in RealtimePublisher

### DIFF
--- a/doc/migration.rst
+++ b/doc/migration.rst
@@ -11,3 +11,9 @@ RealtimeBox
 
   * Update your code with a local message variable and call ``try_publish`` with that variable. (`#323 <https://github.com/ros-controls/realtime_tools/pull/323>`__).
   * ``msg_`` variable is inaccessible now (`#421 <https://github.com/ros-controls/realtime_tools/pull/421>`__).
+
+RealtimePublisher
+*****************
+* ``RealtimePublisher`` is updated with a template constructor that creates the publisher internally, and the legacy constructor taking a pre-created publisher has been deprecated.
+
+  * Instead of creating a publisher first and passing it to the constructor, you can now pass the node (or node interface/pointer), topic name, QoS, and publisher options directly to ``RealtimePublisher``. (`#573 <https://github.com/ros-controls/realtime_tools/pull/573>`__).

--- a/realtime_tools/include/realtime_tools/realtime_publisher.hpp
+++ b/realtime_tools/include/realtime_tools/realtime_publisher.hpp
@@ -40,7 +40,6 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
-#include <future>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -201,12 +200,15 @@ private:
     keep_running_ = true;
     turn_ = State::LOOP_NOT_STARTED;
 
-    std::promise<void> started_promise;
-    auto started_future = started_promise.get_future();
+    thread_ = std::thread(&RealtimePublisher::publishingLoop, this);
 
-    thread_ = std::thread(&RealtimePublisher::publishingLoop, this, std::move(started_promise));
-
-    started_future.wait();
+    // Wait for the thread to be ready before proceeding
+    // This is important to ensure that the thread is properly initialized and ready to handle
+    // messages before any other operations are performed on the RealtimePublisher instance.
+    while (!thread_.joinable() ||
+           turn_.load(std::memory_order_acquire) == State::LOOP_NOT_STARTED) {
+      std::this_thread::sleep_for(std::chrono::microseconds(100));
+    }
   }
 
   /**
@@ -236,16 +238,15 @@ private:
    *
    * The loop continues until keep_running_ is set to false.
    */
-  void publishingLoop(std::promise<void> started_promise)
+  void publishingLoop()
   {
     is_running_ = true;
-    turn_.store(State::REALTIME, std::memory_order_release);
-    started_promise.set_value();
 
     while (keep_running_) {
       MessageT outgoing;
 
       {
+        turn_.store(State::REALTIME, std::memory_order_release);
         // Locks msg_ and copies it to outgoing
         std::unique_lock<std::mutex> lock_(msg_mutex_);
         updated_cond_.wait(lock_, [&] { return turn_ == State::NON_REALTIME || !keep_running_; });
@@ -256,7 +257,6 @@ private:
       if (keep_running_) {
         publisher_->publish(outgoing);
       }
-      turn_.store(State::REALTIME, std::memory_order_release);
     }
     is_running_ = false;
   }

--- a/realtime_tools/include/realtime_tools/realtime_publisher.hpp
+++ b/realtime_tools/include/realtime_tools/realtime_publisher.hpp
@@ -46,6 +46,7 @@
 #include <thread>
 #include <utility>
 
+#include "rclcpp/create_publisher.hpp"
 #include "rclcpp/publisher.hpp"
 
 namespace realtime_tools
@@ -64,6 +65,39 @@ public:
   RCLCPP_SMART_PTR_DEFINITIONS(RealtimePublisher<MessageT>)
 
   /**
+   * \brief Constructor for the realtime publisher that creates the publisher internally
+   *
+   * Starts a dedicated thread for message publishing.
+   * The publishing thread runs the publishingLoop() function to handle message
+   * delivery in a non-realtime context.
+   *
+   * \param node the node (or node interface/pointer) to create the publisher for
+   * \param topic_name the topic name on which we want to publish
+   * \param qos the QoS settings for the publisher
+   * \param options the publisher options
+   */
+  template <typename NodeT>
+  explicit RealtimePublisher(
+    NodeT && node, const std::string & topic_name, const rclcpp::QoS & qos,
+    const rclcpp::PublisherOptions & options = rclcpp::PublisherOptions())
+  : publisher_(
+      rclcpp::create_publisher<MessageT>(std::forward<NodeT>(node), topic_name, qos, options)),
+    is_running_(false),
+    keep_running_(true),
+    turn_(State::LOOP_NOT_STARTED)
+  {
+    thread_ = std::thread(&RealtimePublisher::publishingLoop, this);
+
+    // Wait for the thread to be ready before proceeding
+    // This is important to ensure that the thread is properly initialized and ready to handle
+    // messages before any other operations are performed on the RealtimePublisher instance.
+    while (!thread_.joinable() ||
+           turn_.load(std::memory_order_acquire) == State::LOOP_NOT_STARTED) {
+      std::this_thread::sleep_for(std::chrono::microseconds(100));
+    }
+  }
+
+  /**
    * \brief Constructor for the realtime publisher
    *
    * Starts a dedicated thread for message publishing.
@@ -72,6 +106,7 @@ public:
    *
    * \param publisher the ROS publisher to wrap
    */
+  [[deprecated("Use the constructor that creates the publisher internally instead.")]]
   explicit RealtimePublisher(PublisherSharedPtr publisher)
   : publisher_(publisher), is_running_(false), keep_running_(true), turn_(State::LOOP_NOT_STARTED)
   {

--- a/realtime_tools/include/realtime_tools/realtime_publisher.hpp
+++ b/realtime_tools/include/realtime_tools/realtime_publisher.hpp
@@ -40,6 +40,7 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <future>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -80,21 +81,11 @@ public:
   explicit RealtimePublisher(
     NodeT && node, const std::string & topic_name, const rclcpp::QoS & qos,
     const rclcpp::PublisherOptions & options = rclcpp::PublisherOptions())
-  : publisher_(
-      rclcpp::create_publisher<MessageT>(std::forward<NodeT>(node), topic_name, qos, options)),
-    is_running_(false),
-    keep_running_(true),
-    turn_(State::LOOP_NOT_STARTED)
   {
-    thread_ = std::thread(&RealtimePublisher::publishingLoop, this);
-
-    // Wait for the thread to be ready before proceeding
-    // This is important to ensure that the thread is properly initialized and ready to handle
-    // messages before any other operations are performed on the RealtimePublisher instance.
-    while (!thread_.joinable() ||
-           turn_.load(std::memory_order_acquire) == State::LOOP_NOT_STARTED) {
-      std::this_thread::sleep_for(std::chrono::microseconds(100));
-    }
+    initialize([&]() {
+      return rclcpp::create_publisher<MessageT>(
+        std::forward<NodeT>(node), topic_name, qos, options);
+    });
   }
 
   /**
@@ -108,17 +99,8 @@ public:
    */
   [[deprecated("Use the constructor that creates the publisher internally instead.")]]
   explicit RealtimePublisher(PublisherSharedPtr publisher)
-  : publisher_(publisher), is_running_(false), keep_running_(true), turn_(State::LOOP_NOT_STARTED)
   {
-    thread_ = std::thread(&RealtimePublisher::publishingLoop, this);
-
-    // Wait for the thread to be ready before proceeding
-    // This is important to ensure that the thread is properly initialized and ready to handle
-    // messages before any other operations are performed on the RealtimePublisher instance.
-    while (!thread_.joinable() ||
-           turn_.load(std::memory_order_acquire) == State::LOOP_NOT_STARTED) {
-      std::this_thread::sleep_for(std::chrono::microseconds(100));
-    }
+    initialize([&]() { return publisher; });
   }
 
   /// Destructor
@@ -211,11 +193,27 @@ public:
   const std::mutex & get_mutex() const { return msg_mutex_; }
 
 private:
+  template <typename PublisherCreator>
+  void initialize(PublisherCreator && creator)
+  {
+    publisher_ = creator();
+    is_running_ = false;
+    keep_running_ = true;
+    turn_ = State::LOOP_NOT_STARTED;
+
+    std::promise<void> started_promise;
+    auto started_future = started_promise.get_future();
+
+    thread_ = std::thread(&RealtimePublisher::publishingLoop, this, std::move(started_promise));
+
+    started_future.wait();
+  }
+
   /**
    * \brief Check if the realtime publisher is in a state to publish messages
    * \param lock A unique_lock that is already acquired on the msg_mutex_
    * \return true if the publisher is in a state to publish messages
-  */
+   */
   bool can_publish(std::unique_lock<std::mutex> & lock) const
   {
     return turn_.load(std::memory_order_acquire) == State::REALTIME && lock.owns_lock();
@@ -238,9 +236,10 @@ private:
    *
    * The loop continues until keep_running_ is set to false.
    */
-  void publishingLoop()
+  void publishingLoop(std::promise<void> started_promise)
   {
     is_running_ = true;
+    started_promise.set_value();
 
     while (keep_running_) {
       MessageT outgoing;

--- a/realtime_tools/include/realtime_tools/realtime_publisher.hpp
+++ b/realtime_tools/include/realtime_tools/realtime_publisher.hpp
@@ -215,7 +215,7 @@ private:
    * \brief Check if the realtime publisher is in a state to publish messages
    * \param lock A unique_lock that is already acquired on the msg_mutex_
    * \return true if the publisher is in a state to publish messages
-   */
+  */
   bool can_publish(std::unique_lock<std::mutex> & lock) const
   {
     return turn_.load(std::memory_order_acquire) == State::REALTIME && lock.owns_lock();

--- a/realtime_tools/include/realtime_tools/realtime_publisher.hpp
+++ b/realtime_tools/include/realtime_tools/realtime_publisher.hpp
@@ -239,13 +239,13 @@ private:
   void publishingLoop(std::promise<void> started_promise)
   {
     is_running_ = true;
+    turn_.store(State::REALTIME, std::memory_order_release);
     started_promise.set_value();
 
     while (keep_running_) {
       MessageT outgoing;
 
       {
-        turn_.store(State::REALTIME, std::memory_order_release);
         // Locks msg_ and copies it to outgoing
         std::unique_lock<std::mutex> lock_(msg_mutex_);
         updated_cond_.wait(lock_, [&] { return turn_ == State::NON_REALTIME || !keep_running_; });
@@ -256,6 +256,7 @@ private:
       if (keep_running_) {
         publisher_->publish(outgoing);
       }
+      turn_.store(State::REALTIME, std::memory_order_release);
     }
     is_running_ = false;
   }

--- a/realtime_tools/test/realtime_publisher_tests.cpp
+++ b/realtime_tools/test/realtime_publisher_tests.cpp
@@ -64,8 +64,7 @@ TEST(RealtimePublisher, rt_can_try_publish)
   auto node = std::make_shared<rclcpp::Node>("construct_move_destruct");
   rclcpp::QoS qos(10);
   qos.reliable().transient_local();
-  auto pub = node->create_publisher<StringMsg>("~/rt_publish", qos);
-  RealtimePublisher<StringMsg> rt_pub(pub);
+  RealtimePublisher<StringMsg> rt_pub(node, "~/rt_publish", qos);
   ASSERT_TRUE(rt_pub.can_publish());
 
   // try publish a latched message
@@ -87,6 +86,67 @@ TEST(RealtimePublisher, rt_can_try_publish)
 
   auto sub = node->create_subscription<StringMsg>(
     "~/rt_publish", qos,
+    std::bind(&StringCallback::callback, &str_callback, std::placeholders::_1));
+
+  rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(node);
+  for (size_t i = 0; i < ATTEMPTS && str_callback.msg_.string_value.empty(); ++i) {
+    exec.spin_some();
+    std::this_thread::sleep_for(DELAY);
+  }
+  EXPECT_STREQ(expected_msg, str_callback.msg_.string_value.c_str());
+  rclcpp::shutdown();
+}
+
+TEST(RealtimePublisher, rt_can_try_publish_deprecated)
+{
+  rclcpp::init(0, nullptr);
+  const size_t ATTEMPTS = 10;
+  const std::chrono::milliseconds DELAY(250);
+
+  const char * expected_msg = "Hello World";
+  auto node = std::make_shared<rclcpp::Node>("construct_move_destruct_deprecated");
+  rclcpp::QoS qos(10);
+  qos.reliable().transient_local();
+  auto pub = node->create_publisher<StringMsg>("~/rt_publish_dep", qos);
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  RealtimePublisher<StringMsg> rt_pub(pub);
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+  ASSERT_TRUE(rt_pub.can_publish());
+
+  // try publish a latched message
+  bool publish_success = false;
+  for (std::size_t i = 0; i < ATTEMPTS; ++i) {
+    StringMsg msg;
+    msg.string_value = expected_msg;
+
+    if (rt_pub.can_publish()) {
+      ASSERT_TRUE(rt_pub.try_publish(msg));
+      publish_success = true;
+    }
+    std::this_thread::sleep_for(DELAY);
+  }
+  ASSERT_TRUE(publish_success);
+
+  // make sure subscriber gets it
+  StringCallback str_callback;
+
+  auto sub = node->create_subscription<StringMsg>(
+    "~/rt_publish_dep", qos,
     std::bind(&StringCallback::callback, &str_callback, std::placeholders::_1));
 
   rclcpp::executors::SingleThreadedExecutor exec;

--- a/realtime_tools/test/realtime_publisher_tests.cpp
+++ b/realtime_tools/test/realtime_publisher_tests.cpp
@@ -54,57 +54,51 @@ struct StringCallback
   }
 };
 
-TEST(RealtimePublisher, rt_can_try_publish)
+void verify_publisher(
+  RealtimePublisher<StringMsg> & rt_pub, const std::shared_ptr<rclcpp::Node> & node,
+  const rclcpp::QoS & qos, const std::string & topic)
 {
-  rclcpp::init(0, nullptr);
-  const size_t ATTEMPTS = 10;
-  const std::chrono::milliseconds DELAY(250);
-
   const char * expected_msg = "Hello World";
-  auto node = std::make_shared<rclcpp::Node>("construct_move_destruct");
-  rclcpp::QoS qos(10);
-  qos.reliable().transient_local();
-  RealtimePublisher<StringMsg> rt_pub(node, "~/rt_publish", qos);
   ASSERT_TRUE(rt_pub.can_publish());
-
-  // try publish a latched message
-  bool publish_success = false;
-  for (std::size_t i = 0; i < ATTEMPTS; ++i) {
-    StringMsg msg;
-    msg.string_value = expected_msg;
-
-    if (rt_pub.can_publish()) {
-      ASSERT_TRUE(rt_pub.try_publish(msg));
-      publish_success = true;
-    }
-    std::this_thread::sleep_for(DELAY);
-  }
-  ASSERT_TRUE(publish_success);
 
   // make sure subscriber gets it
   StringCallback str_callback;
-
   auto sub = node->create_subscription<StringMsg>(
-    "~/rt_publish", qos,
-    std::bind(&StringCallback::callback, &str_callback, std::placeholders::_1));
+    topic, qos, std::bind(&StringCallback::callback, &str_callback, std::placeholders::_1));
+
+  StringMsg msg;
+  msg.string_value = expected_msg;
+  ASSERT_TRUE(rt_pub.try_publish(msg));
 
   rclcpp::executors::SingleThreadedExecutor exec;
   exec.add_node(node);
-  for (size_t i = 0; i < ATTEMPTS && str_callback.msg_.string_value.empty(); ++i) {
+
+  auto start_time = std::chrono::steady_clock::now();
+  while (str_callback.msg_.string_value.empty() &&
+         (std::chrono::steady_clock::now() - start_time) < std::chrono::seconds(2)) {
     exec.spin_some();
-    std::this_thread::sleep_for(DELAY);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
+
   EXPECT_STREQ(expected_msg, str_callback.msg_.string_value.c_str());
+}
+
+TEST(RealtimePublisher, rt_can_try_publish)
+{
+  rclcpp::init(0, nullptr);
+  auto node = std::make_shared<rclcpp::Node>("construct_move_destruct");
+  rclcpp::QoS qos(10);
+  qos.reliable().transient_local();
+
+  RealtimePublisher<StringMsg> rt_pub(node, "~/rt_publish", qos);
+  verify_publisher(rt_pub, node, qos, "~/rt_publish");
+
   rclcpp::shutdown();
 }
 
 TEST(RealtimePublisher, rt_can_try_publish_deprecated)
 {
   rclcpp::init(0, nullptr);
-  const size_t ATTEMPTS = 10;
-  const std::chrono::milliseconds DELAY(250);
-
-  const char * expected_msg = "Hello World";
   auto node = std::make_shared<rclcpp::Node>("construct_move_destruct_deprecated");
   rclcpp::QoS qos(10);
   qos.reliable().transient_local();
@@ -126,35 +120,7 @@ TEST(RealtimePublisher, rt_can_try_publish_deprecated)
 #pragma warning(pop)
 #endif
 
-  ASSERT_TRUE(rt_pub.can_publish());
+  verify_publisher(rt_pub, node, qos, "~/rt_publish_dep");
 
-  // try publish a latched message
-  bool publish_success = false;
-  for (std::size_t i = 0; i < ATTEMPTS; ++i) {
-    StringMsg msg;
-    msg.string_value = expected_msg;
-
-    if (rt_pub.can_publish()) {
-      ASSERT_TRUE(rt_pub.try_publish(msg));
-      publish_success = true;
-    }
-    std::this_thread::sleep_for(DELAY);
-  }
-  ASSERT_TRUE(publish_success);
-
-  // make sure subscriber gets it
-  StringCallback str_callback;
-
-  auto sub = node->create_subscription<StringMsg>(
-    "~/rt_publish_dep", qos,
-    std::bind(&StringCallback::callback, &str_callback, std::placeholders::_1));
-
-  rclcpp::executors::SingleThreadedExecutor exec;
-  exec.add_node(node);
-  for (size_t i = 0; i < ATTEMPTS && str_callback.msg_.string_value.empty(); ++i) {
-    exec.spin_some();
-    std::this_thread::sleep_for(DELAY);
-  }
-  EXPECT_STREQ(expected_msg, str_callback.msg_.string_value.c_str());
   rclcpp::shutdown();
 }

--- a/realtime_tools/test/realtime_publisher_tests.cpp
+++ b/realtime_tools/test/realtime_publisher_tests.cpp
@@ -61,14 +61,14 @@ void verify_publisher(
   const char * expected_msg = "Hello World";
   ASSERT_TRUE(rt_pub.can_publish());
 
-  // make sure subscriber gets it
-  StringCallback str_callback;
-  auto sub = node->create_subscription<StringMsg>(
-    topic, qos, std::bind(&StringCallback::callback, &str_callback, std::placeholders::_1));
-
   StringMsg msg;
   msg.string_value = expected_msg;
   ASSERT_TRUE(rt_pub.try_publish(msg));
+
+  // make sure subscriber gets it (created after publishing to verify transient_local latching)
+  StringCallback str_callback;
+  auto sub = node->create_subscription<StringMsg>(
+    topic, qos, std::bind(&StringCallback::callback, &str_callback, std::placeholders::_1));
 
   rclcpp::executors::SingleThreadedExecutor exec;
   exec.add_node(node);


### PR DESCRIPTION
## Description

This PR refactors `RealtimePublisher` by adding a new template constructor that creates the underlying publisher internally. This simplifies using `RealtimePublisher` by removing the need for users to manually instantiate and pass in an `rclcpp::Publisher` object.

This completes and completes the work started in stale PR #469.

Fixes #81

## Is this user-facing behavior change?

Yes (adds a new constructor to the public API and deprecates the old constructor).

## Did you use Generative AI?

No

## Additional Information

Verified locally that the pre-commit checks run and pass successfully:

```bash
pre-commit run --all-files