### PR TITLE
Install libboost-devel instead of boost with python support

### DIFF
--- a/.github/workflows/rolling-binary-build-win.yml
+++ b/.github/workflows/rolling-binary-build-win.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   binary-windows:
-    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-ros-tooling-win-build.yml@master
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-ros-tooling-win-build.yml@fix-win
     with:
       ros_distro: rolling
       pixi_dependencies: libboost-devel compilers

--- a/.github/workflows/rolling-binary-build-win.yml
+++ b/.github/workflows/rolling-binary-build-win.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   binary-windows:
-    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-ros-tooling-win-build.yml@fix-win
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-ros-tooling-win-build.yml@master
     with:
       ros_distro: rolling
       pixi_dependencies: libboost-devel compilers

--- a/.github/workflows/rolling-binary-build-win.yml
+++ b/.github/workflows/rolling-binary-build-win.yml
@@ -29,4 +29,4 @@ jobs:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-ros-tooling-win-build.yml@master
     with:
       ros_distro: rolling
-      pixi_dependencies: boost compilers
+      pixi_dependencies: libboost-devel compilers


### PR DESCRIPTION
<!--
Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.
5. If a PR is merged all commits will get squashed, a linear commit history is not required.
6. Once a PR got reviewed, please don't do force pushes as this will break github UI and subsequent reviews will take more time.
-->

## Description

Jobs failed with 

```
Error:   × failed to solve requirements of environment 'default' for platform 'win-64'
  ├─▶   × failed to solve the environment

  ╰─▶ Cannot solve the request because of: boost * cannot be installed because there are no viable options:
      ├─ boost 1.85.0 would require
      │  └─ libboost-python-devel ==1.85.0 py312h7e22eef_4, which cannot be installed because there are no viable options:
      │     └─ libboost-python-devel 1.85.0 would require
      │        └─ python >=3.12,<3.13.0a0, for which no candidates were found.

```

### Is this user-facing behavior change?
no

### Did you use Generative AI?
no